### PR TITLE
Add engine interfaces to Ouroboros.Abstractions

### DIFF
--- a/src/Ouroboros.Abstractions/Agent/IModelOrchestrator.cs
+++ b/src/Ouroboros.Abstractions/Agent/IModelOrchestrator.cs
@@ -1,0 +1,123 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Model Orchestrator Interface
+// Defines contract for intelligent model and tool selection
+// based on prompt analysis and performance metrics
+// ==========================================================
+
+namespace Ouroboros.Agent;
+
+/// <summary>
+/// Represents metadata about a model's capabilities and performance characteristics.
+/// </summary>
+public sealed record ModelCapability(
+    string ModelName,
+    string[] Strengths,
+    int MaxTokens,
+    double AverageCost,
+    double AverageLatencyMs,
+    ModelType Type);
+
+/// <summary>
+/// Classification of model types for orchestration decisions.
+/// </summary>
+public enum ModelType
+{
+    General,
+    Code,
+    Reasoning,
+    Creative,
+    Summary,
+    Analysis
+}
+
+/// <summary>
+/// Use case classification derived from prompt analysis.
+/// </summary>
+public sealed record UseCase(
+    UseCaseType Type,
+    int EstimatedComplexity,
+    string[] RequiredCapabilities,
+    double PerformanceWeight,
+    double CostWeight);
+
+/// <summary>
+/// Primary use case types for model selection.
+/// </summary>
+public enum UseCaseType
+{
+    CodeGeneration,
+    Reasoning,
+    Creative,
+    Summarization,
+    Analysis,
+    Conversation,
+    ToolUse
+}
+
+/// <summary>
+/// Performance metrics for model/tool execution tracking.
+/// </summary>
+public sealed record PerformanceMetrics(
+    string ResourceName,
+    int ExecutionCount,
+    double AverageLatencyMs,
+    double SuccessRate,
+    DateTime LastUsed,
+    Dictionary<string, double> CustomMetrics);
+
+/// <summary>
+/// Result of orchestrator's model selection decision.
+/// </summary>
+public sealed record OrchestratorDecision(
+    IChatCompletionModel SelectedModel,
+    string ModelName,
+    string Reason,
+    ToolRegistry RecommendedTools,
+    double ConfidenceScore);
+
+/// <summary>
+/// Orchestrates model and tool selection based on prompt analysis and performance metrics.
+/// Implements intelligent routing to optimize for quality, cost, and performance.
+/// </summary>
+public interface IModelOrchestrator
+{
+    /// <summary>
+    /// Analyzes a prompt and selects the optimal model and tool configuration.
+    /// </summary>
+    /// <param name="prompt">The input prompt to analyze</param>
+    /// <param name="context">Optional contextual information</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Orchestrator decision with selected model and tools</returns>
+    Task<Result<OrchestratorDecision, string>> SelectModelAsync(
+        string prompt,
+        Dictionary<string, object>? context = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Classifies a prompt into a use case for model selection.
+    /// </summary>
+    /// <param name="prompt">The prompt to classify</param>
+    /// <returns>Classified use case</returns>
+    UseCase ClassifyUseCase(string prompt);
+
+    /// <summary>
+    /// Registers a model with its capabilities for orchestration.
+    /// </summary>
+    /// <param name="capability">Model capability metadata</param>
+    void RegisterModel(ModelCapability capability);
+
+    /// <summary>
+    /// Records performance metrics for a model or tool execution.
+    /// </summary>
+    /// <param name="resourceName">Name of the model or tool</param>
+    /// <param name="latencyMs">Execution time in milliseconds</param>
+    /// <param name="success">Whether execution succeeded</param>
+    void RecordMetric(string resourceName, double latencyMs, bool success);
+
+    /// <summary>
+    /// Gets current performance metrics for all resources.
+    /// </summary>
+    /// <returns>Dictionary of resource names to their metrics</returns>
+    IReadOnlyDictionary<string, PerformanceMetrics> GetMetrics();
+}

--- a/src/Ouroboros.Abstractions/Agent/IOrchestrator.cs
+++ b/src/Ouroboros.Abstractions/Agent/IOrchestrator.cs
@@ -1,0 +1,297 @@
+// <copyright file="IOrchestrator.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+// ==========================================================
+// Base Orchestrator Interface
+// Unified interface for all orchestrators in the suite
+// ==========================================================
+
+namespace Ouroboros.Agent;
+
+/// <summary>
+/// Represents the execution context for an orchestration operation.
+/// Provides a unified way to pass context information across all orchestrators.
+/// </summary>
+public sealed record OrchestratorContext(
+    string OperationId,
+    Dictionary<string, object> Metadata,
+    CancellationToken CancellationToken = default)
+{
+    /// <summary>
+    /// Creates a new orchestrator context with generated operation ID.
+    /// </summary>
+    public static OrchestratorContext Create(
+        Dictionary<string, object>? metadata = null,
+        CancellationToken ct = default) =>
+        new OrchestratorContext(
+            Guid.NewGuid().ToString(),
+            metadata ?? new Dictionary<string, object>(),
+            ct);
+
+    /// <summary>
+    /// Gets a value from metadata or returns default.
+    /// </summary>
+    public T? GetMetadata<T>(string key, T? defaultValue = default) =>
+        Metadata.TryGetValue(key, out var value) && value is T typed
+            ? typed
+            : defaultValue;
+
+    /// <summary>
+    /// Creates a new context with additional metadata.
+    /// </summary>
+    public OrchestratorContext WithMetadata(string key, object value)
+    {
+        var newMetadata = new Dictionary<string, object>(Metadata) { [key] = value };
+        return this with { Metadata = newMetadata };
+    }
+}
+
+/// <summary>
+/// Configuration options for orchestrator behavior.
+/// Provides a unified configuration pattern across all orchestrators.
+/// </summary>
+public record OrchestratorConfig
+{
+    /// <summary>
+    /// Gets or initializes whether to enable distributed tracing.
+    /// </summary>
+    public bool EnableTracing { get; init; } = true;
+
+    /// <summary>
+    /// Gets or initializes whether to track performance metrics.
+    /// </summary>
+    public bool EnableMetrics { get; init; } = true;
+
+    /// <summary>
+    /// Gets or initializes whether to enable safety checks.
+    /// </summary>
+    public bool EnableSafetyChecks { get; init; } = true;
+
+    /// <summary>
+    /// Gets or initializes the maximum execution timeout.
+    /// </summary>
+    public TimeSpan? ExecutionTimeout { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the retry configuration.
+    /// </summary>
+    public RetryConfig? RetryConfig { get; init; }
+
+    /// <summary>
+    /// Gets or initializes additional custom settings.
+    /// </summary>
+    public Dictionary<string, object> CustomSettings { get; init; } = new();
+
+    /// <summary>
+    /// Creates a default configuration.
+    /// </summary>
+    public static OrchestratorConfig Default() => new OrchestratorConfig();
+
+    /// <summary>
+    /// Gets a custom setting value or returns default.
+    /// </summary>
+    public T? GetSetting<T>(string key, T? defaultValue = default) =>
+        CustomSettings.TryGetValue(key, out var value) && value is T typed
+            ? typed
+            : defaultValue;
+}
+
+/// <summary>
+/// Retry configuration for orchestrator operations.
+/// </summary>
+public sealed record RetryConfig(
+    int MaxRetries = 3,
+    TimeSpan InitialDelay = default,
+    TimeSpan MaxDelay = default,
+    double BackoffMultiplier = 2.0)
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetryConfig"/> class with defaults.
+    /// </summary>
+    public RetryConfig()
+        : this(3, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10), 2.0)
+    {
+    }
+
+    /// <summary>
+    /// Creates a default retry configuration.
+    /// </summary>
+    public static RetryConfig Default() => new RetryConfig();
+}
+
+/// <summary>
+/// Unified metrics for orchestrator performance tracking.
+/// </summary>
+public sealed record OrchestratorMetrics(
+    string OrchestratorName,
+    int TotalExecutions,
+    int SuccessfulExecutions,
+    int FailedExecutions,
+    double AverageLatencyMs,
+    double SuccessRate,
+    DateTime LastExecuted,
+    Dictionary<string, double> CustomMetrics)
+{
+    /// <summary>
+    /// Calculates success rate.
+    /// </summary>
+    public double CalculatedSuccessRate =>
+        TotalExecutions > 0 ? (double)SuccessfulExecutions / TotalExecutions : 0.0;
+
+    /// <summary>
+    /// Gets a custom metric or returns default.
+    /// </summary>
+    public double GetCustomMetric(string key, double defaultValue = 0.0) =>
+        CustomMetrics.TryGetValue(key, out var value) ? value : defaultValue;
+
+    /// <summary>
+    /// Creates initial metrics for a new orchestrator.
+    /// </summary>
+    public static OrchestratorMetrics Initial(string orchestratorName) =>
+        new OrchestratorMetrics(
+            orchestratorName,
+            TotalExecutions: 0,
+            SuccessfulExecutions: 0,
+            FailedExecutions: 0,
+            AverageLatencyMs: 0.0,
+            SuccessRate: 0.0,
+            LastExecuted: DateTime.UtcNow,
+            CustomMetrics: new Dictionary<string, double>());
+
+    /// <summary>
+    /// Records a new execution result.
+    /// </summary>
+    public OrchestratorMetrics RecordExecution(double latencyMs, bool success)
+    {
+        int newTotal = TotalExecutions + 1;
+        int newSuccess = SuccessfulExecutions + (success ? 1 : 0);
+        int newFailed = FailedExecutions + (success ? 0 : 1);
+        double newAvgLatency = ((AverageLatencyMs * TotalExecutions) + latencyMs) / newTotal;
+        double newSuccessRate = (double)newSuccess / newTotal;
+
+        return this with
+        {
+            TotalExecutions = newTotal,
+            SuccessfulExecutions = newSuccess,
+            FailedExecutions = newFailed,
+            AverageLatencyMs = newAvgLatency,
+            SuccessRate = newSuccessRate,
+            LastExecuted = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Adds or updates a custom metric.
+    /// </summary>
+    public OrchestratorMetrics WithCustomMetric(string key, double value)
+    {
+        var newCustomMetrics = new Dictionary<string, double>(CustomMetrics)
+        {
+            [key] = value
+        };
+        return this with { CustomMetrics = newCustomMetrics };
+    }
+}
+
+/// <summary>
+/// Result of an orchestrator execution with typed output.
+/// </summary>
+public sealed record OrchestratorResult<T>(
+    T? Output,
+    bool Success,
+    string? ErrorMessage,
+    OrchestratorMetrics Metrics,
+    TimeSpan ExecutionTime,
+    Dictionary<string, object> Metadata)
+{
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    public static OrchestratorResult<T> Ok(
+        T output,
+        OrchestratorMetrics metrics,
+        TimeSpan executionTime,
+        Dictionary<string, object>? metadata = null) =>
+        new OrchestratorResult<T>(
+            output,
+            Success: true,
+            ErrorMessage: null,
+            metrics,
+            executionTime,
+            metadata ?? new Dictionary<string, object>());
+
+    /// <summary>
+    /// Creates a failed result.
+    /// </summary>
+    public static OrchestratorResult<T> Failure(
+        string errorMessage,
+        OrchestratorMetrics metrics,
+        TimeSpan executionTime,
+        Dictionary<string, object>? metadata = null) =>
+        new OrchestratorResult<T>(
+            Output: default,
+            Success: false,
+            errorMessage,
+            metrics,
+            executionTime,
+            metadata ?? new Dictionary<string, object>());
+
+    /// <summary>
+    /// Converts to Result monad.
+    /// </summary>
+    public Result<T, string> ToResult() =>
+        Success && Output != null
+            ? Result<T, string>.Success(Output)
+            : Result<T, string>.Failure(ErrorMessage ?? "Operation failed");
+
+    /// <summary>
+    /// Gets a metadata value or returns default.
+    /// </summary>
+    public TValue? GetMetadata<TValue>(string key, TValue? defaultValue = default) =>
+        Metadata.TryGetValue(key, out var value) && value is TValue typed
+            ? typed
+            : defaultValue;
+}
+
+/// <summary>
+/// Base interface for all orchestrators in the Ouroboros suite.
+/// Provides a unified contract for orchestration operations with consistent
+/// configuration, metrics tracking, and error handling.
+/// </summary>
+/// <typeparam name="TInput">The input type for orchestration.</typeparam>
+/// <typeparam name="TOutput">The output type from orchestration.</typeparam>
+public interface IOrchestrator<TInput, TOutput>
+{
+    /// <summary>
+    /// Gets the orchestrator's configuration.
+    /// </summary>
+    OrchestratorConfig Configuration { get; }
+
+    /// <summary>
+    /// Gets the orchestrator's current metrics.
+    /// </summary>
+    OrchestratorMetrics Metrics { get; }
+
+    /// <summary>
+    /// Executes the orchestration with the given input and context.
+    /// </summary>
+    /// <param name="input">The input to orchestrate.</param>
+    /// <param name="context">Execution context with metadata and cancellation.</param>
+    /// <returns>Result containing output, metrics, and execution details.</returns>
+    Task<OrchestratorResult<TOutput>> ExecuteAsync(
+        TInput input,
+        OrchestratorContext? context = null);
+
+    /// <summary>
+    /// Validates that the orchestrator is ready to execute.
+    /// </summary>
+    /// <returns>Result indicating readiness with optional error message.</returns>
+    Result<bool, string> ValidateReadiness();
+
+    /// <summary>
+    /// Gets detailed health information about the orchestrator.
+    /// </summary>
+    Task<Dictionary<string, object>> GetHealthAsync(CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/Affect/IHomeostasisPolicy.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/Affect/IHomeostasisPolicy.cs
@@ -1,0 +1,188 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Homeostasis Policy Interface
+// Phase 3: Affective Dynamics - SLA regulation & corrective triggers
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI.Affect;
+
+/// <summary>
+/// Represents a homeostasis policy for maintaining affective equilibrium.
+/// </summary>
+public sealed record HomeostasisRule(
+    Guid Id,
+    string Name,
+    string Description,
+    SignalType TargetSignal,
+    double LowerBound,
+    double UpperBound,
+    double TargetValue,
+    HomeostasisAction Action,
+    double Priority,
+    bool IsActive,
+    DateTime CreatedAt);
+
+/// <summary>
+/// Actions to take when homeostasis is violated.
+/// </summary>
+public enum HomeostasisAction
+{
+    /// <summary>Log the violation but take no action</summary>
+    Log,
+    
+    /// <summary>Send an alert notification</summary>
+    Alert,
+    
+    /// <summary>Reduce workload or task complexity</summary>
+    Throttle,
+    
+    /// <summary>Increase workload or seek challenges</summary>
+    Boost,
+    
+    /// <summary>Pause non-critical operations</summary>
+    Pause,
+    
+    /// <summary>Reset to baseline state</summary>
+    Reset,
+    
+    /// <summary>Execute custom corrective action</summary>
+    Custom
+}
+
+/// <summary>
+/// Result of a policy evaluation.
+/// </summary>
+public sealed record PolicyViolation(
+    Guid RuleId,
+    string RuleName,
+    SignalType Signal,
+    double ObservedValue,
+    double LowerBound,
+    double UpperBound,
+    string ViolationType,
+    HomeostasisAction RecommendedAction,
+    double Severity,
+    DateTime DetectedAt);
+
+/// <summary>
+/// Result of applying a corrective action.
+/// </summary>
+public sealed record CorrectionResult(
+    Guid ViolationId,
+    HomeostasisAction ActionTaken,
+    bool Success,
+    string Message,
+    double ValueBefore,
+    double ValueAfter,
+    DateTime AppliedAt);
+
+/// <summary>
+/// Interface for homeostasis policy management.
+/// Enforces SLA boundaries and triggers corrective actions.
+/// </summary>
+public interface IHomeostasisPolicy
+{
+    /// <summary>
+    /// Adds a new homeostasis rule.
+    /// </summary>
+    /// <param name="name">Rule name</param>
+    /// <param name="description">Rule description</param>
+    /// <param name="targetSignal">Signal type to monitor</param>
+    /// <param name="lowerBound">Lower acceptable bound</param>
+    /// <param name="upperBound">Upper acceptable bound</param>
+    /// <param name="targetValue">Target equilibrium value</param>
+    /// <param name="action">Action to take on violation</param>
+    /// <param name="priority">Rule priority (higher = more important)</param>
+    /// <returns>The created rule</returns>
+    HomeostasisRule AddRule(
+        string name,
+        string description,
+        SignalType targetSignal,
+        double lowerBound,
+        double upperBound,
+        double targetValue,
+        HomeostasisAction action,
+        double priority = 1.0);
+
+    /// <summary>
+    /// Updates an existing rule.
+    /// </summary>
+    /// <param name="ruleId">Rule ID</param>
+    /// <param name="lowerBound">New lower bound</param>
+    /// <param name="upperBound">New upper bound</param>
+    /// <param name="targetValue">New target value</param>
+    void UpdateRule(Guid ruleId, double? lowerBound = null, double? upperBound = null, double? targetValue = null);
+
+    /// <summary>
+    /// Enables or disables a rule.
+    /// </summary>
+    /// <param name="ruleId">Rule ID</param>
+    /// <param name="isActive">Whether the rule should be active</param>
+    void SetRuleActive(Guid ruleId, bool isActive);
+
+    /// <summary>
+    /// Gets all rules.
+    /// </summary>
+    /// <param name="activeOnly">Only return active rules</param>
+    /// <returns>List of rules</returns>
+    List<HomeostasisRule> GetRules(bool activeOnly = true);
+
+    /// <summary>
+    /// Evaluates current state against all active policies.
+    /// </summary>
+    /// <param name="state">Current affective state</param>
+    /// <returns>List of policy violations</returns>
+    List<PolicyViolation> EvaluatePolicies(AffectiveState state);
+
+    /// <summary>
+    /// Applies corrective action for a violation.
+    /// </summary>
+    /// <param name="violation">The policy violation</param>
+    /// <param name="monitor">The valence monitor to apply corrections to</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Correction result</returns>
+    Task<CorrectionResult> ApplyCorrectionAsync(
+        PolicyViolation violation,
+        IValenceMonitor monitor,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets violation history.
+    /// </summary>
+    /// <param name="count">Number of violations to retrieve</param>
+    /// <returns>List of recent violations</returns>
+    List<PolicyViolation> GetViolationHistory(int count = 50);
+
+    /// <summary>
+    /// Gets correction history.
+    /// </summary>
+    /// <param name="count">Number of corrections to retrieve</param>
+    /// <returns>List of recent corrections</returns>
+    List<CorrectionResult> GetCorrectionHistory(int count = 50);
+
+    /// <summary>
+    /// Registers a custom correction handler.
+    /// </summary>
+    /// <param name="name">Handler name</param>
+    /// <param name="handler">Handler function</param>
+    void RegisterCustomHandler(string name, Func<PolicyViolation, IValenceMonitor, Task<CorrectionResult>> handler);
+
+    /// <summary>
+    /// Gets policy health summary.
+    /// </summary>
+    /// <returns>Policy health metrics</returns>
+    PolicyHealthSummary GetHealthSummary();
+}
+
+/// <summary>
+/// Summary of policy health.
+/// </summary>
+public sealed record PolicyHealthSummary(
+    int TotalRules,
+    int ActiveRules,
+    int TotalViolations,
+    int RecentViolations,
+    int TotalCorrections,
+    int SuccessfulCorrections,
+    double CorrectionSuccessRate,
+    Dictionary<SignalType, int> ViolationsBySignal);

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/Affect/IPriorityModulator.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/Affect/IPriorityModulator.cs
@@ -1,0 +1,153 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Priority Modulator Interface
+// Phase 3: Affective Dynamics - Threat/opportunity appraisal
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI.Affect;
+
+/// <summary>
+/// Represents a task with priority modulation.
+/// </summary>
+public sealed record PrioritizedTask(
+    Guid Id,
+    string Name,
+    string Description,
+    double BasePriority,
+    double ModulatedPriority,
+    TaskAppraisal Appraisal,
+    DateTime CreatedAt,
+    DateTime? DueAt,
+    TaskStatus Status,
+    Dictionary<string, object> Metadata);
+
+/// <summary>
+/// Result of threat/opportunity appraisal.
+/// </summary>
+public sealed record TaskAppraisal(
+    double ThreatLevel,
+    double OpportunityScore,
+    double UrgencyFactor,
+    double RelevanceScore,
+    string Rationale);
+
+/// <summary>
+/// Task status.
+/// </summary>
+public enum TaskStatus
+{
+    /// <summary>Task is pending execution</summary>
+    Pending,
+    
+    /// <summary>Task is currently executing</summary>
+    InProgress,
+    
+    /// <summary>Task completed successfully</summary>
+    Completed,
+    
+    /// <summary>Task failed</summary>
+    Failed,
+    
+    /// <summary>Task was cancelled</summary>
+    Cancelled,
+    
+    /// <summary>Task is blocked by another task</summary>
+    Blocked
+}
+
+/// <summary>
+/// Interface for affect-driven priority modulation.
+/// Adjusts task priorities based on affective state and threat/opportunity appraisal.
+/// </summary>
+public interface IPriorityModulator
+{
+    /// <summary>
+    /// Adds a task to the priority queue.
+    /// </summary>
+    /// <param name="name">Task name</param>
+    /// <param name="description">Task description</param>
+    /// <param name="basePriority">Base priority (0.0 to 1.0)</param>
+    /// <param name="dueAt">Optional due date</param>
+    /// <param name="metadata">Optional metadata</param>
+    /// <returns>The created task</returns>
+    PrioritizedTask AddTask(
+        string name,
+        string description,
+        double basePriority,
+        DateTime? dueAt = null,
+        Dictionary<string, object>? metadata = null);
+
+    /// <summary>
+    /// Appraises a task for threat/opportunity.
+    /// </summary>
+    /// <param name="taskId">Task ID</param>
+    /// <param name="state">Current affective state</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Task appraisal</returns>
+    Task<TaskAppraisal> AppraiseTaskAsync(
+        Guid taskId,
+        AffectiveState state,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Modulates all task priorities based on current affective state.
+    /// </summary>
+    /// <param name="state">Current affective state</param>
+    void ModulatePriorities(AffectiveState state);
+
+    /// <summary>
+    /// Gets the next task to execute based on modulated priorities.
+    /// </summary>
+    /// <returns>Next task or null if queue is empty</returns>
+    PrioritizedTask? GetNextTask();
+
+    /// <summary>
+    /// Gets all tasks in priority order.
+    /// </summary>
+    /// <param name="includeDone">Include completed/cancelled tasks</param>
+    /// <returns>List of tasks</returns>
+    List<PrioritizedTask> GetTasks(bool includeDone = false);
+
+    /// <summary>
+    /// Updates task status.
+    /// </summary>
+    /// <param name="taskId">Task ID</param>
+    /// <param name="status">New status</param>
+    void UpdateTaskStatus(Guid taskId, TaskStatus status);
+
+    /// <summary>
+    /// Removes a task from the queue.
+    /// </summary>
+    /// <param name="taskId">Task ID</param>
+    void RemoveTask(Guid taskId);
+
+    /// <summary>
+    /// Gets queue statistics.
+    /// </summary>
+    /// <returns>Queue statistics</returns>
+    QueueStatistics GetStatistics();
+
+    /// <summary>
+    /// Reorders tasks based on threat level (high threat = higher priority).
+    /// </summary>
+    void PrioritizeByThreat();
+
+    /// <summary>
+    /// Reorders tasks based on opportunity score (high opportunity = higher priority).
+    /// </summary>
+    void PrioritizeByOpportunity();
+}
+
+/// <summary>
+/// Queue statistics.
+/// </summary>
+public sealed record QueueStatistics(
+    int TotalTasks,
+    int PendingTasks,
+    int InProgressTasks,
+    int CompletedTasks,
+    int FailedTasks,
+    double AverageBasePriority,
+    double AverageModulatedPriority,
+    double HighestThreat,
+    double HighestOpportunity);

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/Affect/IValenceMonitor.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/Affect/IValenceMonitor.cs
@@ -1,0 +1,152 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Valence Monitor Interface
+// Phase 3: Affective Dynamics - Synthetic affective states
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI.Affect;
+
+/// <summary>
+/// Represents the current affective state of an agent.
+/// </summary>
+public sealed record AffectiveState(
+    Guid Id,
+    double Valence,
+    double Stress,
+    double Confidence,
+    double Curiosity,
+    double Arousal,
+    DateTime Timestamp,
+    Dictionary<string, object> Metadata);
+
+/// <summary>
+/// Represents a valence signal measurement.
+/// </summary>
+public sealed record ValenceSignal(
+    string Source,
+    double Value,
+    SignalType Type,
+    DateTime Timestamp,
+    TimeSpan? Duration);
+
+/// <summary>
+/// Types of valence signals.
+/// </summary>
+public enum SignalType
+{
+    /// <summary>Stress indicator from system load or failures</summary>
+    Stress,
+    
+    /// <summary>Confidence from successful task completions</summary>
+    Confidence,
+    
+    /// <summary>Curiosity from novelty detection</summary>
+    Curiosity,
+    
+    /// <summary>General valence (positive/negative affect)</summary>
+    Valence,
+    
+    /// <summary>Arousal level (energy/activation)</summary>
+    Arousal
+}
+
+/// <summary>
+/// Result of stress detection using signal analysis.
+/// </summary>
+public sealed record StressDetectionResult(
+    double StressLevel,
+    double Frequency,
+    double Amplitude,
+    bool IsAnomalous,
+    List<double> SpectralPeaks,
+    string Analysis,
+    DateTime DetectedAt);
+
+/// <summary>
+/// Configuration for affect monitoring.
+/// </summary>
+public sealed record AffectConfig(
+    double StressThreshold = 0.7,
+    double ConfidenceDecayRate = 0.01,
+    double CuriosityBoostFactor = 0.2,
+    int SignalHistorySize = 1000,
+    int FourierWindowSize = 64);
+
+/// <summary>
+/// Interface for monitoring and computing synthetic affective states.
+/// Tracks valence, stress, confidence, curiosity, and arousal.
+/// </summary>
+public interface IValenceMonitor
+{
+    /// <summary>
+    /// Gets the current affective state.
+    /// </summary>
+    /// <returns>Current affective state</returns>
+    AffectiveState GetCurrentState();
+
+    /// <summary>
+    /// Records a valence signal from a source.
+    /// </summary>
+    /// <param name="source">Signal source identifier</param>
+    /// <param name="value">Signal value (typically -1.0 to 1.0 for valence, 0.0 to 1.0 for others)</param>
+    /// <param name="type">Type of signal</param>
+    void RecordSignal(string source, double value, SignalType type);
+
+    /// <summary>
+    /// Computes stress level using Fourier-based signal analysis.
+    /// Analyzes frequency patterns in recent stress signals to detect anomalies.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Stress detection result with spectral analysis</returns>
+    Task<StressDetectionResult> DetectStressAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates confidence based on task outcome.
+    /// </summary>
+    /// <param name="taskId">Task identifier</param>
+    /// <param name="success">Whether the task succeeded</param>
+    /// <param name="weight">Weight of this outcome (0.0 to 1.0)</param>
+    void UpdateConfidence(string taskId, bool success, double weight = 1.0);
+
+    /// <summary>
+    /// Updates curiosity based on novelty detection.
+    /// </summary>
+    /// <param name="noveltyScore">Novelty score (0.0 to 1.0)</param>
+    /// <param name="context">Context description</param>
+    void UpdateCuriosity(double noveltyScore, string context);
+
+    /// <summary>
+    /// Gets recent signals of a specific type.
+    /// </summary>
+    /// <param name="type">Signal type</param>
+    /// <param name="count">Number of signals to retrieve</param>
+    /// <returns>List of recent signals</returns>
+    List<ValenceSignal> GetRecentSignals(SignalType type, int count = 100);
+
+    /// <summary>
+    /// Gets the signal history for spectral analysis.
+    /// </summary>
+    /// <param name="type">Signal type</param>
+    /// <returns>Array of signal values</returns>
+    double[] GetSignalHistory(SignalType type);
+
+    /// <summary>
+    /// Computes the running average for a signal type.
+    /// </summary>
+    /// <param name="type">Signal type</param>
+    /// <param name="windowSize">Window size for averaging</param>
+    /// <returns>Running average value</returns>
+    double GetRunningAverage(SignalType type, int windowSize = 10);
+
+    /// <summary>
+    /// Resets all affective states to baseline.
+    /// </summary>
+    void Reset();
+
+    /// <summary>
+    /// Gets affective state history.
+    /// </summary>
+    /// <param name="count">Number of states to retrieve</param>
+    /// <returns>List of recent affective states</returns>
+    List<AffectiveState> GetStateHistory(int count = 50);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/IMemoryStore.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/IMemoryStore.cs
@@ -1,0 +1,81 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Persistent Memory Store - Long-term learning and experience
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents a learning experience stored in memory.
+/// </summary>
+public sealed record Experience(
+    Guid Id,
+    string Goal,
+    Plan Plan,
+    ExecutionResult Execution,
+    VerificationResult Verification,
+    DateTime Timestamp,
+    Dictionary<string, object> Metadata);
+
+/// <summary>
+/// Memory query for retrieving relevant experiences.
+/// </summary>
+public sealed record MemoryQuery(
+    string Goal,
+    Dictionary<string, object>? Context,
+    int MaxResults,
+    double MinSimilarity);
+
+/// <summary>
+/// Interface for persistent memory storage and retrieval.
+/// Enables continual learning from past executions.
+/// </summary>
+public interface IMemoryStore
+{
+    /// <summary>
+    /// Stores an experience in long-term memory.
+    /// </summary>
+    /// <param name="experience">The experience to store</param>
+    /// <param name="ct">Cancellation token</param>
+    Task StoreExperienceAsync(Experience experience, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieves relevant experiences for a goal.
+    /// </summary>
+    /// <param name="query">Memory query parameters</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of relevant experiences sorted by relevance</returns>
+    Task<List<Experience>> RetrieveRelevantExperiencesAsync(
+        MemoryQuery query,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets statistics about stored experiences.
+    /// </summary>
+    /// <returns>Memory statistics</returns>
+    Task<MemoryStatistics> GetStatisticsAsync();
+
+    /// <summary>
+    /// Clears all experiences from memory.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    Task ClearAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets an experience by ID.
+    /// </summary>
+    /// <param name="id">Experience ID</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Experience if found, null otherwise</returns>
+    Task<Experience?> GetExperienceAsync(Guid id, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Statistics about the memory store.
+/// </summary>
+public sealed record MemoryStatistics(
+    int TotalExperiences,
+    int SuccessfulExecutions,
+    int FailedExecutions,
+    double AverageQualityScore,
+    Dictionary<string, int> GoalCounts);

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/IMetaAIPlannerOrchestrator.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/IMetaAIPlannerOrchestrator.cs
@@ -1,0 +1,108 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Meta-AI Layer v2 - Planner/Executor/Verifier Orchestrator
+// Implements continual learning with plan-execute-verify loop
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents a plan with steps and expected outcomes.
+/// </summary>
+public sealed record Plan(
+    string Goal,
+    List<PlanStep> Steps,
+    Dictionary<string, double> ConfidenceScores,
+    DateTime CreatedAt);
+
+/// <summary>
+/// Represents a single step in a plan.
+/// </summary>
+public sealed record PlanStep(
+    string Action,
+    Dictionary<string, object> Parameters,
+    string ExpectedOutcome,
+    double ConfidenceScore);
+
+/// <summary>
+/// Represents the result of executing a plan.
+/// </summary>
+public sealed record ExecutionResult(
+    Plan Plan,
+    List<StepResult> StepResults,
+    bool Success,
+    string FinalOutput,
+    Dictionary<string, object> Metadata,
+    TimeSpan Duration);
+
+/// <summary>
+/// Represents the result of executing a single plan step.
+/// </summary>
+public sealed record StepResult(
+    PlanStep Step,
+    bool Success,
+    string Output,
+    string? Error,
+    TimeSpan Duration,
+    Dictionary<string, object> ObservedState);
+
+/// <summary>
+/// Represents verification result with feedback for improvement.
+/// </summary>
+public sealed record VerificationResult(
+    ExecutionResult Execution,
+    bool Verified,
+    double QualityScore,
+    List<string> Issues,
+    List<string> Improvements,
+    string? RevisedPlan);
+
+/// <summary>
+/// Core interface for Meta-AI v2 planner/executor/verifier orchestrator.
+/// Implements continual learning through plan-execute-verify loop.
+/// </summary>
+public interface IMetaAIPlannerOrchestrator
+{
+    /// <summary>
+    /// Plans how to accomplish a goal based on available tools and past experience.
+    /// </summary>
+    /// <param name="goal">The goal to accomplish</param>
+    /// <param name="context">Additional context information</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>A plan with steps and confidence scores</returns>
+    Task<Result<Plan, string>> PlanAsync(
+        string goal,
+        Dictionary<string, object>? context = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Executes a plan step by step with monitoring.
+    /// </summary>
+    /// <param name="plan">The plan to execute</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Execution result with outcomes for each step</returns>
+    Task<Result<ExecutionResult, string>> ExecuteAsync(
+        Plan plan,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Verifies execution results and provides feedback for improvement.
+    /// </summary>
+    /// <param name="execution">The execution result to verify</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Verification result with quality score and suggestions</returns>
+    Task<Result<VerificationResult, string>> VerifyAsync(
+        ExecutionResult execution,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Learns from execution experience to improve future planning.
+    /// </summary>
+    /// <param name="verification">The verification result to learn from</param>
+    void LearnFromExecution(VerificationResult verification);
+
+    /// <summary>
+    /// Gets performance metrics for the orchestrator.
+    /// </summary>
+    IReadOnlyDictionary<string, PerformanceMetrics> GetMetrics();
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/IMetricsStore.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/IMetricsStore.cs
@@ -1,0 +1,68 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Metrics Store Interface
+// Defines contract for persistent storage of performance metrics
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Interface for persistent storage and retrieval of performance metrics.
+/// Enables long-term learning across orchestrator sessions.
+/// </summary>
+public interface IMetricsStore
+{
+    /// <summary>
+    /// Stores or updates metrics for a resource.
+    /// </summary>
+    /// <param name="metrics">The metrics to store</param>
+    /// <param name="ct">Cancellation token</param>
+    Task StoreMetricsAsync(PerformanceMetrics metrics, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieves metrics for a specific resource.
+    /// </summary>
+    /// <param name="resourceName">Name of the resource</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Metrics if found, null otherwise</returns>
+    Task<PerformanceMetrics?> GetMetricsAsync(string resourceName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieves all stored metrics.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Dictionary of all metrics by resource name</returns>
+    Task<IReadOnlyDictionary<string, PerformanceMetrics>> GetAllMetricsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes metrics for a specific resource.
+    /// </summary>
+    /// <param name="resourceName">Name of the resource</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>True if removed, false if not found</returns>
+    Task<bool> RemoveMetricsAsync(string resourceName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Clears all stored metrics.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    Task ClearAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets statistics about the metrics store.
+    /// </summary>
+    /// <returns>Metrics store statistics</returns>
+    Task<MetricsStoreStatistics> GetStatisticsAsync();
+}
+
+/// <summary>
+/// Statistics about the metrics store.
+/// </summary>
+public sealed record MetricsStoreStatistics(
+    int TotalResources,
+    int TotalExecutions,
+    double OverallSuccessRate,
+    double AverageLatencyMs,
+    DateTime? OldestMetric,
+    DateTime? NewestMetric);
+

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/ISafetyGuard.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/ISafetyGuard.cs
@@ -1,0 +1,116 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Safety Guard - Permission-based safe execution
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents a permission for executing operations.
+/// </summary>
+public sealed record Permission(
+    string Name,
+    string Description,
+    PermissionLevel Level,
+    List<string> AllowedActions);
+
+/// <summary>
+/// Permission levels for operations.
+/// </summary>
+public enum PermissionLevel
+{
+    /// <summary>
+    /// Read-only operations, no side effects.
+    /// </summary>
+    ReadOnly,
+
+    /// <summary>
+    /// Can write to temporary/isolated storage.
+    /// </summary>
+    Isolated,
+
+    /// <summary>
+    /// Can modify user data without confirmation.
+    /// </summary>
+    UserData,
+
+    /// <summary>
+    /// Can modify user data with explicit confirmation (stricter than UserData).
+    /// </summary>
+    UserDataWithConfirmation,
+
+    /// <summary>
+    /// Can modify system state.
+    /// </summary>
+    System,
+
+    /// <summary>
+    /// Unrestricted access (use with extreme caution).
+    /// </summary>
+    Unrestricted
+}
+
+/// <summary>
+/// Safety check result.
+/// </summary>
+public sealed record SafetyCheckResult(
+    bool Safe,
+    List<string> Violations,
+    List<string> Warnings,
+    PermissionLevel RequiredLevel);
+
+/// <summary>
+/// Interface for safety and permission checks.
+/// Ensures operations are executed within authorized boundaries.
+/// </summary>
+public interface ISafetyGuard
+{
+    /// <summary>
+    /// Checks if an operation is safe to execute.
+    /// </summary>
+    /// <param name="operation">The operation to check</param>
+    /// <param name="parameters">Operation parameters</param>
+    /// <param name="currentLevel">Current permission level</param>
+    /// <returns>Safety check result</returns>
+    SafetyCheckResult CheckSafety(
+        string operation,
+        Dictionary<string, object> parameters,
+        PermissionLevel currentLevel);
+
+    /// <summary>
+    /// Validates tool execution is permitted.
+    /// </summary>
+    /// <param name="toolName">The tool to execute</param>
+    /// <param name="arguments">Tool arguments</param>
+    /// <param name="currentLevel">Current permission level</param>
+    /// <returns>True if permitted, false otherwise</returns>
+    bool IsToolExecutionPermitted(
+        string toolName,
+        string arguments,
+        PermissionLevel currentLevel);
+
+    /// <summary>
+    /// Sandboxes a plan step for safe execution.
+    /// </summary>
+    /// <param name="step">The plan step to sandbox</param>
+    /// <returns>Sandboxed step with safety restrictions applied</returns>
+    PlanStep SandboxStep(PlanStep step);
+
+    /// <summary>
+    /// Gets required permission level for an action.
+    /// </summary>
+    /// <param name="action">The action to check</param>
+    /// <returns>Required permission level</returns>
+    PermissionLevel GetRequiredPermission(string action);
+
+    /// <summary>
+    /// Registers a permission policy.
+    /// </summary>
+    /// <param name="permission">The permission to register</param>
+    void RegisterPermission(Permission permission);
+
+    /// <summary>
+    /// Gets all registered permissions.
+    /// </summary>
+    IReadOnlyList<Permission> GetPermissions();
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/ISkillRegistry.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/ISkillRegistry.cs
@@ -1,0 +1,81 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Skill Registry - Learn and store reusable skills
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents a learned skill that can be reused.
+/// </summary>
+public sealed record Skill(
+    string Name,
+    string Description,
+    List<string> Prerequisites,
+    List<PlanStep> Steps,
+    double SuccessRate,
+    int UsageCount,
+    DateTime CreatedAt,
+    DateTime LastUsed);
+
+/// <summary>
+/// Interface for skill acquisition and management.
+/// Enables the system to learn and reuse successful patterns.
+/// </summary>
+public interface ISkillRegistry
+{
+    /// <summary>
+    /// Registers a new skill learned from successful execution.
+    /// </summary>
+    /// <param name="skill">The skill to register</param>
+    void RegisterSkill(Skill skill);
+
+    /// <summary>
+    /// Registers a new skill asynchronously with immediate persistence.
+    /// Use this method when you need to ensure the skill is persisted before continuing.
+    /// </summary>
+    /// <param name="skill">The skill to register</param>
+    /// <param name="ct">Cancellation token</param>
+    Task RegisterSkillAsync(Skill skill, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds skills that match the given goal and context.
+    /// </summary>
+    /// <param name="goal">The goal to accomplish</param>
+    /// <param name="context">Optional context information</param>
+    /// <returns>List of matching skills sorted by relevance</returns>
+    Task<List<Skill>> FindMatchingSkillsAsync(
+        string goal,
+        Dictionary<string, object>? context = null);
+
+    /// <summary>
+    /// Gets a skill by name.
+    /// </summary>
+    /// <param name="name">The skill name</param>
+    /// <returns>The skill if found, null otherwise</returns>
+    Skill? GetSkill(string name);
+
+    /// <summary>
+    /// Updates skill metrics after execution.
+    /// </summary>
+    /// <param name="name">The skill name</param>
+    /// <param name="success">Whether the execution succeeded</param>
+    void RecordSkillExecution(string name, bool success);
+
+    /// <summary>
+    /// Gets all registered skills.
+    /// </summary>
+    /// <returns>All skills in the registry</returns>
+    IReadOnlyList<Skill> GetAllSkills();
+
+    /// <summary>
+    /// Extracts and registers a skill from a successful execution.
+    /// </summary>
+    /// <param name="execution">The successful execution result</param>
+    /// <param name="skillName">The name for the new skill</param>
+    /// <param name="description">Description of what the skill does</param>
+    Task<Result<Skill, string>> ExtractSkillAsync(
+        ExecutionResult execution,
+        string skillName,
+        string description);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/IUncertaintyRouter.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/IUncertaintyRouter.cs
@@ -1,0 +1,98 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Uncertainty-Aware Router - Route based on confidence
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Routing decision with confidence information.
+/// </summary>
+public sealed record RoutingDecision(
+    string Route,
+    string Reason,
+    double Confidence,
+    Dictionary<string, object> Metadata);
+
+/// <summary>
+/// Fallback strategy when confidence is low.
+/// </summary>
+public enum FallbackStrategy
+{
+    /// <summary>
+    /// Use default general-purpose model.
+    /// </summary>
+    UseDefault,
+
+    /// <summary>
+    /// Ask for human clarification.
+    /// </summary>
+    RequestClarification,
+
+    /// <summary>
+    /// Use ensemble of multiple models.
+    /// </summary>
+    UseEnsemble,
+
+    /// <summary>
+    /// Decompose into simpler sub-tasks.
+    /// </summary>
+    DecomposeTask,
+
+    /// <summary>
+    /// Retrieve more context before deciding.
+    /// </summary>
+    GatherMoreContext
+}
+
+/// <summary>
+/// Interface for uncertainty-aware routing decisions.
+/// Routes tasks based on confidence levels with fallback strategies.
+/// </summary>
+public interface IUncertaintyRouter
+{
+    /// <summary>
+    /// Routes a task based on confidence analysis.
+    /// </summary>
+    /// <param name="task">The task to route</param>
+    /// <param name="context">Optional context information</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Routing decision with confidence score</returns>
+    Task<Result<RoutingDecision, string>> RouteAsync(
+        string task,
+        Dictionary<string, object>? context = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Determines fallback strategy for low-confidence scenarios.
+    /// </summary>
+    /// <param name="task">The task being routed</param>
+    /// <param name="confidence">The confidence score (0-1)</param>
+    /// <returns>Recommended fallback strategy</returns>
+    FallbackStrategy DetermineFallback(string task, double confidence);
+
+    /// <summary>
+    /// Calculates confidence for a given decision.
+    /// </summary>
+    /// <param name="task">The task to assess</param>
+    /// <param name="route">The proposed route</param>
+    /// <param name="context">Optional context</param>
+    /// <returns>Confidence score between 0 and 1</returns>
+    Task<double> CalculateConfidenceAsync(
+        string task,
+        string route,
+        Dictionary<string, object>? context = null);
+
+    /// <summary>
+    /// Gets the minimum confidence threshold for direct routing.
+    /// Below this threshold, fallback strategies are triggered.
+    /// </summary>
+    double MinimumConfidenceThreshold { get; }
+
+    /// <summary>
+    /// Updates routing performance metrics.
+    /// </summary>
+    /// <param name="decision">The routing decision made</param>
+    /// <param name="success">Whether the routing was successful</param>
+    void RecordRoutingOutcome(RoutingDecision decision, bool success);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/MetaLearning/IMetaLearner.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/MetaLearning/IMetaLearner.cs
@@ -1,0 +1,75 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Meta-Learner Interface
+// Enables learning how to learn more effectively
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI.MetaLearning;
+
+/// <summary>
+/// Interface for meta-learning capabilities.
+/// Enables the agent to learn how to learn more effectively by optimizing learning strategies,
+/// performing few-shot adaptation, and suggesting optimal hyperparameters.
+/// </summary>
+public interface IMetaLearner
+{
+    /// <summary>
+    /// Analyzes learning history and optimizes learning strategy.
+    /// </summary>
+    /// <param name="history">Historical learning episodes to analyze</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Optimized learning strategy or error message</returns>
+    Task<Result<LearningStrategy, string>> OptimizeLearningStrategyAsync(
+        IReadOnlyList<LearningEpisode> history,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Performs few-shot adaptation to a new task.
+    /// </summary>
+    /// <param name="taskDescription">Description of the task to adapt to</param>
+    /// <param name="examples">Few-shot examples for the task</param>
+    /// <param name="maxExamples">Maximum number of examples to use (default: 5)</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Adapted model or error message</returns>
+    Task<Result<AdaptedModel, string>> FewShotAdaptAsync(
+        string taskDescription,
+        IReadOnlyList<TaskExample> examples,
+        int maxExamples = 5,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Suggests optimal hyperparameters for a given task type.
+    /// </summary>
+    /// <param name="taskType">The type of task (e.g., "classification", "generation")</param>
+    /// <param name="context">Additional context information</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Hyperparameter configuration or error message</returns>
+    Task<Result<HyperparameterConfig, string>> SuggestHyperparametersAsync(
+        string taskType,
+        Dictionary<string, object>? context = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Evaluates how well current learning approach works.
+    /// </summary>
+    /// <param name="evaluationWindow">Time window for evaluation</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Learning efficiency report or error message</returns>
+    Task<Result<LearningEfficiencyReport, string>> EvaluateLearningEfficiencyAsync(
+        TimeSpan evaluationWindow,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Identifies transferable meta-knowledge from past learning.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of meta-knowledge insights or error message</returns>
+    Task<Result<List<MetaKnowledge>, string>> ExtractMetaKnowledgeAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Records a learning episode for meta-learning.
+    /// </summary>
+    /// <param name="episode">The learning episode to record</param>
+    void RecordLearningEpisode(LearningEpisode episode);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ICapabilityRegistry.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ICapabilityRegistry.cs
@@ -1,0 +1,92 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Capability Registry Interface
+// Agent self-model and capability tracking
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents a capability that the agent possesses.
+/// </summary>
+public sealed record AgentCapability(
+    string Name,
+    string Description,
+    List<string> RequiredTools,
+    double SuccessRate,
+    double AverageLatency,
+    List<string> KnownLimitations,
+    int UsageCount,
+    DateTime CreatedAt,
+    DateTime LastUsed,
+    Dictionary<string, object> Metadata);
+
+/// <summary>
+/// Interface for agent capability self-modeling.
+/// Allows the agent to understand and track its own capabilities.
+/// </summary>
+public interface ICapabilityRegistry
+{
+    /// <summary>
+    /// Gets all capabilities the agent possesses.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of agent capabilities</returns>
+    Task<List<AgentCapability>> GetCapabilitiesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks if the agent can handle a given task.
+    /// </summary>
+    /// <param name="task">The task description</param>
+    /// <param name="context">Optional context information</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>True if the agent can handle the task, false otherwise</returns>
+    Task<bool> CanHandleAsync(
+        string task,
+        Dictionary<string, object>? context = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a specific capability by name.
+    /// </summary>
+    /// <param name="name">The capability name</param>
+    /// <returns>The capability if found, null otherwise</returns>
+    AgentCapability? GetCapability(string name);
+
+    /// <summary>
+    /// Updates capability metrics after execution.
+    /// </summary>
+    /// <param name="name">The capability name</param>
+    /// <param name="result">The execution result</param>
+    /// <param name="ct">Cancellation token</param>
+    Task UpdateCapabilityAsync(
+        string name,
+        ExecutionResult result,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Registers a new capability.
+    /// </summary>
+    /// <param name="capability">The capability to register</param>
+    void RegisterCapability(AgentCapability capability);
+
+    /// <summary>
+    /// Identifies capability gaps for a given task.
+    /// </summary>
+    /// <param name="task">The task description</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of missing capabilities needed for the task</returns>
+    Task<List<string>> IdentifyCapabilityGapsAsync(
+        string task,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Suggests alternatives when a task cannot be handled.
+    /// </summary>
+    /// <param name="task">The task description</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of alternative approaches or suggestions</returns>
+    Task<List<string>> SuggestAlternativesAsync(
+        string task,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ICuriosityEngine.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ICuriosityEngine.cs
@@ -1,0 +1,96 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Curiosity Engine Interface
+// Intrinsic motivation and curiosity-driven exploration
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents a novel exploration opportunity.
+/// </summary>
+public sealed record ExplorationOpportunity(
+    string Description,
+    double NoveltyScore,
+    double InformationGainEstimate,
+    List<string> Prerequisites,
+    DateTime IdentifiedAt);
+
+/// <summary>
+/// Configuration for curiosity-driven behavior.
+/// </summary>
+public sealed record CuriosityEngineConfig(
+    double ExplorationThreshold = 0.6,
+    double ExploitationBias = 0.7,
+    int MaxExplorationPerSession = 5,
+    bool EnableSafeExploration = true,
+    double MinSafetyScore = 0.8);
+
+/// <summary>
+/// Interface for curiosity-driven exploration capabilities.
+/// Enables autonomous learning through intrinsic motivation.
+/// </summary>
+public interface ICuriosityEngine
+{
+    /// <summary>
+    /// Computes the novelty score for a potential action or plan.
+    /// </summary>
+    /// <param name="plan">The plan to evaluate</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Novelty score (0-1, higher = more novel)</returns>
+    Task<double> ComputeNoveltyAsync(
+        Plan plan,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generates an exploratory plan to learn something new.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Exploratory plan</returns>
+    Task<Result<Plan, string>> GenerateExploratoryPlanAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Decides whether to explore or exploit based on current state.
+    /// </summary>
+    /// <param name="currentGoal">The current goal being considered</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>True if should explore, false if should exploit</returns>
+    Task<bool> ShouldExploreAsync(
+        string? currentGoal = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Identifies novel exploration opportunities.
+    /// </summary>
+    /// <param name="maxOpportunities">Maximum number of opportunities to return</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of exploration opportunities</returns>
+    Task<List<ExplorationOpportunity>> IdentifyExplorationOpportunitiesAsync(
+        int maxOpportunities = 5,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Estimates the information gain from exploring a particular area.
+    /// </summary>
+    /// <param name="explorationDescription">Description of what to explore</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Estimated information gain (0-1)</returns>
+    Task<double> EstimateInformationGainAsync(
+        string explorationDescription,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Records the outcome of an exploration attempt.
+    /// </summary>
+    /// <param name="plan">The exploratory plan that was executed</param>
+    /// <param name="execution">The execution result</param>
+    /// <param name="actualNovelty">The actual novelty discovered</param>
+    void RecordExploration(Plan plan, ExecutionResult execution, double actualNovelty);
+
+    /// <summary>
+    /// Gets exploration statistics.
+    /// </summary>
+    /// <returns>Dictionary of exploration metrics</returns>
+    Dictionary<string, double> GetExplorationStats();
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/IGoalHierarchy.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/IGoalHierarchy.cs
@@ -1,0 +1,143 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Goal Hierarchy Interface
+// Hierarchical goal decomposition and value alignment
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Types of goals in the hierarchy.
+/// </summary>
+public enum GoalType
+{
+    /// <summary>Primary goal - the main objective</summary>
+    Primary,
+
+    /// <summary>Secondary goal - supporting objective</summary>
+    Secondary,
+
+    /// <summary>Instrumental goal - means to achieve other goals</summary>
+    Instrumental,
+
+    /// <summary>Safety goal - constraint or boundary condition</summary>
+    Safety
+}
+
+/// <summary>
+/// Represents a goal with hierarchical structure.
+/// </summary>
+public sealed record Goal(
+    Guid Id,
+    string Description,
+    GoalType Type,
+    double Priority,
+    Goal? ParentGoal,
+    List<Goal> Subgoals,
+    Dictionary<string, object> Constraints,
+    DateTime CreatedAt,
+    bool IsComplete,
+    string? CompletionReason)
+{
+    /// <summary>
+    /// Creates a new goal with default values.
+    /// </summary>
+    public Goal(string description, GoalType type, double priority)
+        : this(
+            Guid.NewGuid(),
+            description,
+            type,
+            priority,
+            ParentGoal: null,
+            Subgoals: new List<Goal>(),
+            Constraints: new Dictionary<string, object>(),
+            DateTime.UtcNow,
+            IsComplete: false,
+            CompletionReason: null)
+    {
+    }
+}
+
+/// <summary>
+/// Result of goal conflict detection.
+/// </summary>
+public sealed record GoalConflict(
+    Goal Goal1,
+    Goal Goal2,
+    string ConflictType,
+    string Description,
+    List<string> SuggestedResolutions);
+
+/// <summary>
+/// Interface for hierarchical goal management and value alignment.
+/// </summary>
+public interface IGoalHierarchy
+{
+    /// <summary>
+    /// Adds a goal to the hierarchy.
+    /// </summary>
+    /// <param name="goal">The goal to add</param>
+    void AddGoal(Goal goal);
+
+    /// <summary>
+    /// Gets a goal by ID.
+    /// </summary>
+    /// <param name="id">The goal ID</param>
+    /// <returns>The goal if found, null otherwise</returns>
+    Goal? GetGoal(Guid id);
+
+    /// <summary>
+    /// Gets all active goals (not completed).
+    /// </summary>
+    /// <returns>List of active goals</returns>
+    List<Goal> GetActiveGoals();
+
+    /// <summary>
+    /// Decomposes a complex goal into subgoals.
+    /// </summary>
+    /// <param name="goal">The goal to decompose</param>
+    /// <param name="maxDepth">Maximum decomposition depth</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>The goal with populated subgoals</returns>
+    Task<Result<Goal, string>> DecomposeGoalAsync(
+        Goal goal,
+        int maxDepth = 3,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Detects conflicts between goals.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of detected conflicts</returns>
+    Task<List<GoalConflict>> DetectConflictsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks if a goal aligns with safety constraints and values.
+    /// </summary>
+    /// <param name="goal">The goal to check</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>True if aligned, false otherwise with reason</returns>
+    Task<Result<bool, string>> CheckValueAlignmentAsync(
+        Goal goal,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks a goal as complete.
+    /// </summary>
+    /// <param name="id">The goal ID</param>
+    /// <param name="reason">Completion reason</param>
+    void CompleteGoal(Guid id, string reason);
+
+    /// <summary>
+    /// Gets the goal hierarchy as a tree structure.
+    /// </summary>
+    /// <returns>Root goals with their subgoal trees</returns>
+    List<Goal> GetGoalTree();
+
+    /// <summary>
+    /// Prioritizes goals based on dependencies and importance.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Ordered list of goals to pursue</returns>
+    Task<List<Goal>> PrioritizeGoalsAsync(CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/IHypothesisEngine.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/IHypothesisEngine.cs
@@ -1,0 +1,126 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Hypothesis Engine Interface
+// Scientific reasoning and hypothesis testing
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents a hypothesis about system behavior or domain knowledge.
+/// </summary>
+public sealed record Hypothesis(
+    Guid Id,
+    string Statement,
+    string Domain,
+    double Confidence,
+    List<string> SupportingEvidence,
+    List<string> CounterEvidence,
+    DateTime CreatedAt,
+    bool Tested,
+    bool? Validated);
+
+/// <summary>
+/// Represents an experiment designed to test a hypothesis.
+/// </summary>
+public sealed record Experiment(
+    Guid Id,
+    Hypothesis Hypothesis,
+    string Description,
+    List<PlanStep> Steps,
+    Dictionary<string, object> ExpectedOutcomes,
+    DateTime DesignedAt);
+
+/// <summary>
+/// Result of hypothesis testing.
+/// </summary>
+public sealed record HypothesisTestResult(
+    Hypothesis Hypothesis,
+    Experiment Experiment,
+    ExecutionResult Execution,
+    bool HypothesisSupported,
+    double ConfidenceAdjustment,
+    string Explanation,
+    DateTime TestedAt);
+
+/// <summary>
+/// Configuration for hypothesis generation and testing.
+/// </summary>
+public sealed record HypothesisEngineConfig(
+    double MinConfidenceForTesting = 0.3,
+    int MaxHypothesesPerDomain = 10,
+    bool EnableAbductiveReasoning = true,
+    bool AutoGenerateCounterExamples = true);
+
+/// <summary>
+/// Interface for hypothesis generation and scientific reasoning.
+/// Enables the agent to form and test hypotheses about its environment.
+/// </summary>
+public interface IHypothesisEngine
+{
+    /// <summary>
+    /// Generates a hypothesis to explain an observation or pattern.
+    /// </summary>
+    /// <param name="observation">The observation to explain</param>
+    /// <param name="context">Optional context information</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Generated hypothesis</returns>
+    Task<Result<Hypothesis, string>> GenerateHypothesisAsync(
+        string observation,
+        Dictionary<string, object>? context = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Designs an experiment to test a hypothesis.
+    /// </summary>
+    /// <param name="hypothesis">The hypothesis to test</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Designed experiment</returns>
+    Task<Result<Experiment, string>> DesignExperimentAsync(
+        Hypothesis hypothesis,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Tests a hypothesis by executing an experiment.
+    /// </summary>
+    /// <param name="hypothesis">The hypothesis to test</param>
+    /// <param name="experiment">The experiment to execute</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Test result with validation</returns>
+    Task<Result<HypothesisTestResult, string>> TestHypothesisAsync(
+        Hypothesis hypothesis,
+        Experiment experiment,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Uses abductive reasoning to infer the best explanation for observations.
+    /// </summary>
+    /// <param name="observations">List of observations</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Best explanation hypothesis</returns>
+    Task<Result<Hypothesis, string>> AbductiveReasoningAsync(
+        List<string> observations,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets all hypotheses for a specific domain.
+    /// </summary>
+    /// <param name="domain">The domain to filter by</param>
+    /// <returns>List of hypotheses</returns>
+    List<Hypothesis> GetHypothesesByDomain(string domain);
+
+    /// <summary>
+    /// Updates a hypothesis based on new evidence.
+    /// </summary>
+    /// <param name="hypothesisId">ID of the hypothesis to update</param>
+    /// <param name="evidence">New evidence (supporting or counter)</param>
+    /// <param name="supports">Whether evidence supports the hypothesis</param>
+    void UpdateHypothesis(Guid hypothesisId, string evidence, bool supports);
+
+    /// <summary>
+    /// Gets the confidence trend for a hypothesis over time.
+    /// </summary>
+    /// <param name="hypothesisId">ID of the hypothesis</param>
+    /// <returns>List of confidence values over time</returns>
+    List<(DateTime time, double confidence)> GetConfidenceTrend(Guid hypothesisId);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ISelfEvaluator.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ISelfEvaluator.cs
@@ -1,0 +1,99 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Self-Evaluator Interface
+// Metacognitive monitoring and self-improvement
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents a self-assessment of agent performance.
+/// </summary>
+public sealed record SelfAssessment(
+    double OverallPerformance,
+    double ConfidenceCalibration,
+    double SkillAcquisitionRate,
+    Dictionary<string, double> CapabilityScores,
+    List<string> Strengths,
+    List<string> Weaknesses,
+    DateTime AssessmentTime,
+    string Summary);
+
+/// <summary>
+/// Represents an insight gained from self-reflection.
+/// </summary>
+public sealed record Insight(
+    string Category,
+    string Description,
+    double Confidence,
+    List<string> SupportingEvidence,
+    DateTime DiscoveredAt);
+
+/// <summary>
+/// Represents a plan for self-improvement.
+/// </summary>
+public sealed record ImprovementPlan(
+    string Goal,
+    List<string> Actions,
+    Dictionary<string, double> ExpectedImprovements,
+    TimeSpan EstimatedDuration,
+    double Priority,
+    DateTime CreatedAt);
+
+/// <summary>
+/// Interface for agent self-evaluation and metacognition.
+/// Enables autonomous performance assessment and improvement planning.
+/// </summary>
+public interface ISelfEvaluator
+{
+    /// <summary>
+    /// Evaluates current performance across all capabilities.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Comprehensive self-assessment</returns>
+    Task<Result<SelfAssessment, string>> EvaluatePerformanceAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generates insights from recent experiences and performance data.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of insights discovered</returns>
+    Task<List<Insight>> GenerateInsightsAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Suggests improvement strategies based on weaknesses.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Prioritized improvement plan</returns>
+    Task<Result<ImprovementPlan, string>> SuggestImprovementsAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Tracks confidence calibration over time.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Calibration score (1.0 = perfect calibration)</returns>
+    Task<double> GetConfidenceCalibrationAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Records a prediction and its actual outcome for calibration.
+    /// </summary>
+    /// <param name="predictedConfidence">Predicted confidence (0-1)</param>
+    /// <param name="actualSuccess">Actual outcome</param>
+    void RecordPrediction(double predictedConfidence, bool actualSuccess);
+
+    /// <summary>
+    /// Gets performance trends over time.
+    /// </summary>
+    /// <param name="metric">The metric to analyze (e.g., "success_rate", "skill_count")</param>
+    /// <param name="timeWindow">Time window for trend analysis</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Trend data points</returns>
+    Task<List<(DateTime Time, double Value)>> GetPerformanceTrendAsync(
+        string metric,
+        TimeSpan timeWindow,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ISkillExtractor.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ISkillExtractor.cs
@@ -1,0 +1,68 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Skill Extractor Interface
+// Automatic extraction of reusable skills from successful executions
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Configuration for skill extraction behavior.
+/// </summary>
+public sealed record SkillExtractionConfig(
+    double MinQualityThreshold = 0.8,
+    int MinStepsForExtraction = 2,
+    int MaxStepsPerSkill = 10,
+    bool EnableAutoParameterization = true,
+    bool EnableSkillVersioning = true);
+
+/// <summary>
+/// Interface for automatic skill extraction from successful executions.
+/// Analyzes execution patterns and extracts reusable skills.
+/// </summary>
+public interface ISkillExtractor
+{
+    /// <summary>
+    /// Extracts a skill from a successful execution.
+    /// </summary>
+    /// <param name="execution">The successful execution result</param>
+    /// <param name="verification">The verification result with quality metrics</param>
+    /// <param name="config">Optional extraction configuration</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Extracted skill or error message</returns>
+    Task<Result<Skill, string>> ExtractSkillAsync(
+        ExecutionResult execution,
+        VerificationResult verification,
+        SkillExtractionConfig? config = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Determines if a skill should be extracted from the given verification result.
+    /// </summary>
+    /// <param name="verification">The verification result to analyze</param>
+    /// <param name="config">Optional extraction configuration</param>
+    /// <returns>True if skill should be extracted, false otherwise</returns>
+    Task<bool> ShouldExtractSkillAsync(
+        VerificationResult verification,
+        SkillExtractionConfig? config = null);
+
+    /// <summary>
+    /// Generates a descriptive name for the extracted skill using LLM.
+    /// </summary>
+    /// <param name="execution">The execution to analyze</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Generated skill name</returns>
+    Task<string> GenerateSkillNameAsync(
+        ExecutionResult execution,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generates a description for the extracted skill using LLM.
+    /// </summary>
+    /// <param name="execution">The execution to analyze</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Generated skill description</returns>
+    Task<string> GenerateSkillDescriptionAsync(
+        ExecutionResult execution,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ITransferLearner.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfImprovement/ITransferLearner.cs
@@ -1,0 +1,86 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Transfer Learning Interface
+// Domain adaptation and analogical reasoning
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Represents the result of a skill transfer attempt.
+/// </summary>
+public sealed record TransferResult(
+    Skill AdaptedSkill,
+    double TransferabilityScore,
+    string SourceDomain,
+    string TargetDomain,
+    List<string> Adaptations,
+    DateTime TransferredAt);
+
+/// <summary>
+/// Configuration for transfer learning behavior.
+/// </summary>
+public sealed record TransferLearningConfig(
+    double MinTransferabilityThreshold = 0.5,
+    int MaxAdaptationAttempts = 3,
+    bool EnableAnalogicalReasoning = true,
+    bool TrackTransferHistory = true);
+
+/// <summary>
+/// Interface for transfer learning capabilities.
+/// Enables applying learned skills across different domains.
+/// </summary>
+public interface ITransferLearner
+{
+    /// <summary>
+    /// Adapts a skill from one domain to another.
+    /// </summary>
+    /// <param name="sourceSkill">The skill to adapt</param>
+    /// <param name="targetDomain">The target domain description</param>
+    /// <param name="config">Optional configuration</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Adapted skill or error message</returns>
+    Task<Result<TransferResult, string>> AdaptSkillToDomainAsync(
+        Skill sourceSkill,
+        string targetDomain,
+        TransferLearningConfig? config = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Estimates how well a skill can transfer to a new domain.
+    /// </summary>
+    /// <param name="skill">The skill to evaluate</param>
+    /// <param name="targetDomain">The target domain</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Transferability score (0-1)</returns>
+    Task<double> EstimateTransferabilityAsync(
+        Skill skill,
+        string targetDomain,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds analogies between domains to guide transfer.
+    /// </summary>
+    /// <param name="sourceDomain">Source domain description</param>
+    /// <param name="targetDomain">Target domain description</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of analogical mappings</returns>
+    Task<List<(string source, string target, double confidence)>> FindAnalogiesAsync(
+        string sourceDomain,
+        string targetDomain,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the transfer history for a skill.
+    /// </summary>
+    /// <param name="skillName">Name of the skill</param>
+    /// <returns>List of transfer attempts</returns>
+    List<TransferResult> GetTransferHistory(string skillName);
+
+    /// <summary>
+    /// Validates if a transferred skill works in the target domain.
+    /// </summary>
+    /// <param name="transferResult">The transfer result to validate</param>
+    /// <param name="success">Whether the validation was successful</param>
+    void RecordTransferValidation(TransferResult transferResult, bool success);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfModel/IGlobalWorkspace.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfModel/IGlobalWorkspace.cs
@@ -1,0 +1,154 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Global Workspace Interface
+// Phase 2: Shared working memory with attention policies
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI.SelfModel;
+
+/// <summary>
+/// Priority level for workspace items.
+/// </summary>
+public enum WorkspacePriority
+{
+    /// <summary>Low priority - background information</summary>
+    Low = 0,
+    
+    /// <summary>Normal priority - standard working memory</summary>
+    Normal = 1,
+    
+    /// <summary>High priority - important information requiring attention</summary>
+    High = 2,
+    
+    /// <summary>Critical priority - urgent information</summary>
+    Critical = 3
+}
+
+/// <summary>
+/// Represents an item in the global workspace.
+/// </summary>
+public sealed record WorkspaceItem(
+    Guid Id,
+    string Content,
+    WorkspacePriority Priority,
+    string Source,
+    DateTime CreatedAt,
+    DateTime ExpiresAt,
+    List<string> Tags,
+    Dictionary<string, object> Metadata)
+{
+    /// <summary>
+    /// Gets the attention weight based on priority, recency, and expiration.
+    /// </summary>
+    public double GetAttentionWeight()
+    {
+        double priorityWeight = (int)Priority / 3.0; // 0.0 to 1.0
+        double recencyWeight = 1.0 - Math.Min(1.0, (DateTime.UtcNow - CreatedAt).TotalHours / 24.0);
+        double urgencyWeight = ExpiresAt < DateTime.UtcNow.AddHours(1) ? 1.0 : 0.0;
+        
+        return (priorityWeight * 0.5) + (recencyWeight * 0.3) + (urgencyWeight * 0.2);
+    }
+}
+
+/// <summary>
+/// Attention policy configuration.
+/// </summary>
+public sealed record AttentionPolicy(
+    int MaxWorkspaceSize,
+    int MaxHighPriorityItems,
+    TimeSpan DefaultItemLifetime,
+    double MinAttentionThreshold);
+
+/// <summary>
+/// Workspace broadcast event.
+/// </summary>
+public sealed record WorkspaceBroadcast(
+    WorkspaceItem Item,
+    string BroadcastReason,
+    DateTime BroadcastTime);
+
+/// <summary>
+/// Interface for global workspace management.
+/// Implements shared working memory with attention-based policies.
+/// </summary>
+public interface IGlobalWorkspace
+{
+    /// <summary>
+    /// Adds an item to the workspace.
+    /// </summary>
+    /// <param name="content">Item content</param>
+    /// <param name="priority">Priority level</param>
+    /// <param name="source">Source of the item</param>
+    /// <param name="tags">Tags for categorization</param>
+    /// <param name="lifetime">Optional custom lifetime</param>
+    /// <returns>The created workspace item</returns>
+    WorkspaceItem AddItem(
+        string content,
+        WorkspacePriority priority,
+        string source,
+        List<string>? tags = null,
+        TimeSpan? lifetime = null);
+
+    /// <summary>
+    /// Gets items currently in the workspace, ordered by attention weight.
+    /// </summary>
+    /// <param name="minPriority">Minimum priority filter</param>
+    /// <returns>List of workspace items ordered by attention weight</returns>
+    List<WorkspaceItem> GetItems(WorkspacePriority minPriority = WorkspacePriority.Low);
+
+    /// <summary>
+    /// Gets high-priority items requiring immediate attention.
+    /// </summary>
+    /// <returns>List of high-priority items</returns>
+    List<WorkspaceItem> GetHighPriorityItems();
+
+    /// <summary>
+    /// Removes an item from the workspace.
+    /// </summary>
+    /// <param name="itemId">Item ID to remove</param>
+    /// <returns>True if removed, false if not found</returns>
+    bool RemoveItem(Guid itemId);
+
+    /// <summary>
+    /// Broadcasts a high-priority item to all listeners.
+    /// </summary>
+    /// <param name="item">Item to broadcast</param>
+    /// <param name="reason">Reason for broadcast</param>
+    void BroadcastItem(WorkspaceItem item, string reason);
+
+    /// <summary>
+    /// Gets recent broadcasts.
+    /// </summary>
+    /// <param name="count">Number of broadcasts to retrieve</param>
+    /// <returns>List of recent broadcasts</returns>
+    List<WorkspaceBroadcast> GetRecentBroadcasts(int count = 10);
+
+    /// <summary>
+    /// Searches workspace items by tags.
+    /// </summary>
+    /// <param name="tags">Tags to search for</param>
+    /// <returns>Items matching any of the tags</returns>
+    List<WorkspaceItem> SearchByTags(List<string> tags);
+
+    /// <summary>
+    /// Cleans up expired items and applies attention policies.
+    /// </summary>
+    void ApplyAttentionPolicies();
+
+    /// <summary>
+    /// Gets workspace statistics.
+    /// </summary>
+    /// <returns>Current workspace statistics</returns>
+    WorkspaceStatistics GetStatistics();
+}
+
+/// <summary>
+/// Statistics about the global workspace.
+/// </summary>
+public sealed record WorkspaceStatistics(
+    int TotalItems,
+    int HighPriorityItems,
+    int CriticalItems,
+    int ExpiredItems,
+    double AverageAttentionWeight,
+    Dictionary<string, int> ItemsBySource);

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfModel/IIdentityGraph.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfModel/IIdentityGraph.cs
@@ -1,0 +1,171 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Identity Graph Interface
+// Phase 2: Agent identity with capabilities, resources, commitments, performance
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI.SelfModel;
+
+/// <summary>
+/// Represents a resource tracked by the agent.
+/// </summary>
+public sealed record AgentResource(
+    string Name,
+    string Type,
+    double Available,
+    double Total,
+    string Unit,
+    DateTime LastUpdated,
+    Dictionary<string, object> Metadata);
+
+/// <summary>
+/// Represents a commitment made by the agent.
+/// </summary>
+public sealed record AgentCommitment(
+    Guid Id,
+    string Description,
+    DateTime Deadline,
+    double Priority,
+    CommitmentStatus Status,
+    double ProgressPercent,
+    List<string> Dependencies,
+    Dictionary<string, object> Metadata,
+    DateTime CreatedAt,
+    DateTime? CompletedAt);
+
+/// <summary>
+/// Status of an agent commitment.
+/// </summary>
+public enum CommitmentStatus
+{
+    /// <summary>Commitment is planned but not started</summary>
+    Planned,
+    
+    /// <summary>Commitment is in progress</summary>
+    InProgress,
+    
+    /// <summary>Commitment is completed successfully</summary>
+    Completed,
+    
+    /// <summary>Commitment failed</summary>
+    Failed,
+    
+    /// <summary>Commitment was cancelled</summary>
+    Cancelled,
+    
+    /// <summary>Commitment is at risk of missing deadline</summary>
+    AtRisk
+}
+
+/// <summary>
+/// Performance metrics for the agent.
+/// </summary>
+public sealed record AgentPerformance(
+    double OverallSuccessRate,
+    double AverageResponseTime,
+    int TotalTasks,
+    int SuccessfulTasks,
+    int FailedTasks,
+    Dictionary<string, double> CapabilitySuccessRates,
+    Dictionary<string, double> ResourceUtilization,
+    DateTime MeasurementPeriodStart,
+    DateTime MeasurementPeriodEnd);
+
+/// <summary>
+/// Complete identity state of the agent.
+/// </summary>
+public sealed record AgentIdentityState(
+    Guid AgentId,
+    string Name,
+    List<AgentCapability> Capabilities,
+    List<AgentResource> Resources,
+    List<AgentCommitment> Commitments,
+    AgentPerformance Performance,
+    DateTime StateTimestamp,
+    Dictionary<string, object> Metadata);
+
+/// <summary>
+/// Interface for agent identity graph management.
+/// Tracks capabilities, resources, commitments, and performance.
+/// </summary>
+public interface IIdentityGraph
+{
+    /// <summary>
+    /// Gets the complete identity state of the agent.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Current agent identity state</returns>
+    Task<AgentIdentityState> GetStateAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Registers or updates a resource.
+    /// </summary>
+    /// <param name="resource">The resource to register</param>
+    void RegisterResource(AgentResource resource);
+
+    /// <summary>
+    /// Gets current resource availability.
+    /// </summary>
+    /// <param name="resourceName">Name of the resource</param>
+    /// <returns>Resource information if found</returns>
+    AgentResource? GetResource(string resourceName);
+
+    /// <summary>
+    /// Creates a new commitment.
+    /// </summary>
+    /// <param name="description">Commitment description</param>
+    /// <param name="deadline">Deadline for completion</param>
+    /// <param name="priority">Priority level (0.0-1.0)</param>
+    /// <param name="dependencies">List of dependency IDs</param>
+    /// <returns>The created commitment</returns>
+    AgentCommitment CreateCommitment(
+        string description,
+        DateTime deadline,
+        double priority,
+        List<string>? dependencies = null);
+
+    /// <summary>
+    /// Updates commitment status and progress.
+    /// </summary>
+    /// <param name="commitmentId">Commitment ID</param>
+    /// <param name="status">New status</param>
+    /// <param name="progressPercent">Progress percentage (0-100)</param>
+    void UpdateCommitment(Guid commitmentId, CommitmentStatus status, double progressPercent);
+
+    /// <summary>
+    /// Gets all active commitments.
+    /// </summary>
+    /// <returns>List of active commitments ordered by priority</returns>
+    List<AgentCommitment> GetActiveCommitments();
+
+    /// <summary>
+    /// Gets commitments at risk of missing deadline.
+    /// </summary>
+    /// <returns>List of at-risk commitments</returns>
+    List<AgentCommitment> GetAtRiskCommitments();
+
+    /// <summary>
+    /// Updates performance metrics.
+    /// </summary>
+    /// <param name="taskResult">Result of a completed task</param>
+    void RecordTaskResult(ExecutionResult taskResult);
+
+    /// <summary>
+    /// Gets performance summary for a specific time window.
+    /// </summary>
+    /// <param name="timeWindow">Time window to analyze</param>
+    /// <returns>Performance metrics for the window</returns>
+    AgentPerformance GetPerformanceSummary(TimeSpan timeWindow);
+
+    /// <summary>
+    /// Persists the current identity state.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    Task SaveStateAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Loads identity state from persistence.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    Task LoadStateAsync(CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/SelfModel/IPredictiveMonitor.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/SelfModel/IPredictiveMonitor.cs
@@ -1,0 +1,154 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Predictive Monitor Interface
+// Phase 2: Predictive self-monitoring with forecasts vs outcomes
+// ==========================================================
+
+namespace Ouroboros.Agent.MetaAI.SelfModel;
+
+/// <summary>
+/// Represents a forecast made by the agent.
+/// </summary>
+public sealed record Forecast(
+    Guid Id,
+    string Description,
+    string MetricName,
+    double PredictedValue,
+    double Confidence,
+    DateTime PredictionTime,
+    DateTime TargetTime,
+    ForecastStatus Status,
+    double? ActualValue,
+    Dictionary<string, object> Metadata);
+
+/// <summary>
+/// Status of a forecast.
+/// </summary>
+public enum ForecastStatus
+{
+    /// <summary>Forecast is pending - target time not reached</summary>
+    Pending,
+    
+    /// <summary>Forecast verified - outcome matches prediction</summary>
+    Verified,
+    
+    /// <summary>Forecast failed - outcome differs from prediction</summary>
+    Failed,
+    
+    /// <summary>Forecast cancelled - no longer relevant</summary>
+    Cancelled
+}
+
+/// <summary>
+/// Calibration metrics for forecast accuracy.
+/// </summary>
+public sealed record ForecastCalibration(
+    int TotalForecasts,
+    int VerifiedForecasts,
+    int FailedForecasts,
+    double AverageConfidence,
+    double AverageAccuracy,
+    double BrierScore,
+    double CalibrationError,
+    Dictionary<string, double> MetricAccuracies);
+
+/// <summary>
+/// Anomaly detection result.
+/// </summary>
+public sealed record AnomalyDetection(
+    string MetricName,
+    double ObservedValue,
+    double ExpectedValue,
+    double Deviation,
+    bool IsAnomaly,
+    string Severity,
+    DateTime DetectedAt,
+    List<string> PossibleCauses);
+
+/// <summary>
+/// Interface for predictive monitoring and forecast tracking.
+/// Compares predictions with outcomes for self-calibration.
+/// </summary>
+public interface IPredictiveMonitor
+{
+    /// <summary>
+    /// Creates a new forecast.
+    /// </summary>
+    /// <param name="description">Forecast description</param>
+    /// <param name="metricName">Name of the metric being forecast</param>
+    /// <param name="predictedValue">Predicted value</param>
+    /// <param name="confidence">Confidence level (0.0-1.0)</param>
+    /// <param name="targetTime">When the forecast should be validated</param>
+    /// <returns>The created forecast</returns>
+    Forecast CreateForecast(
+        string description,
+        string metricName,
+        double predictedValue,
+        double confidence,
+        DateTime targetTime);
+
+    /// <summary>
+    /// Updates a forecast with the actual outcome.
+    /// </summary>
+    /// <param name="forecastId">Forecast ID</param>
+    /// <param name="actualValue">Actual observed value</param>
+    void UpdateForecastOutcome(Guid forecastId, double actualValue);
+
+    /// <summary>
+    /// Gets all pending forecasts.
+    /// </summary>
+    /// <returns>List of pending forecasts</returns>
+    List<Forecast> GetPendingForecasts();
+
+    /// <summary>
+    /// Gets forecasts for a specific metric.
+    /// </summary>
+    /// <param name="metricName">Metric name</param>
+    /// <param name="includeCompleted">Include completed forecasts</param>
+    /// <returns>List of forecasts for the metric</returns>
+    List<Forecast> GetForecastsByMetric(string metricName, bool includeCompleted = true);
+
+    /// <summary>
+    /// Gets forecast calibration metrics.
+    /// </summary>
+    /// <param name="timeWindow">Time window for calibration calculation</param>
+    /// <returns>Calibration metrics</returns>
+    ForecastCalibration GetCalibration(TimeSpan timeWindow);
+
+    /// <summary>
+    /// Detects anomalies in observed metrics.
+    /// </summary>
+    /// <param name="metricName">Metric to check</param>
+    /// <param name="observedValue">Observed value</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Anomaly detection result</returns>
+    Task<AnomalyDetection> DetectAnomalyAsync(
+        string metricName,
+        double observedValue,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets recent anomalies.
+    /// </summary>
+    /// <param name="count">Number of anomalies to retrieve</param>
+    /// <returns>List of recent anomalies</returns>
+    List<AnomalyDetection> GetRecentAnomalies(int count = 10);
+
+    /// <summary>
+    /// Forecasts future performance based on trends.
+    /// </summary>
+    /// <param name="metricName">Metric to forecast</param>
+    /// <param name="horizon">Time horizon for forecast</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Forecast for the metric</returns>
+    Task<Result<Forecast, string>> ForecastMetricAsync(
+        string metricName,
+        TimeSpan horizon,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Validates all pending forecasts that have reached their target time.
+    /// </summary>
+    /// <returns>Number of forecasts validated</returns>
+    int ValidatePendingForecasts();
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/WorldModel/IPredictors.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/WorldModel/IPredictors.cs
@@ -1,0 +1,53 @@
+// <copyright file="IPredictors.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Agent.MetaAI.WorldModel;
+
+/// <summary>
+/// Interface for predicting next states given current state and action.
+/// Follows functional programming principles with async operations.
+/// </summary>
+public interface IStatePredictor
+{
+    /// <summary>
+    /// Predicts the next state given current state and action.
+    /// </summary>
+    /// <param name="current">The current state.</param>
+    /// <param name="action">The action to take.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The predicted next state.</returns>
+    Task<State> PredictAsync(State current, Action action, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Interface for predicting rewards for state-action-next state transitions.
+/// Follows functional programming principles with async operations.
+/// </summary>
+public interface IRewardPredictor
+{
+    /// <summary>
+    /// Predicts the reward for a transition.
+    /// </summary>
+    /// <param name="current">The current state.</param>
+    /// <param name="action">The action taken.</param>
+    /// <param name="next">The resulting next state.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The predicted reward value.</returns>
+    Task<double> PredictAsync(State current, Action action, State next, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Interface for predicting whether a state is terminal (episode ending).
+/// Follows functional programming principles with async operations.
+/// </summary>
+public interface ITerminalPredictor
+{
+    /// <summary>
+    /// Predicts whether the given state is terminal.
+    /// </summary>
+    /// <param name="state">The state to check.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if the state is terminal, false otherwise.</returns>
+    Task<bool> PredictAsync(State state, CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/MetaAI/WorldModel/IWorldModelEngine.cs
+++ b/src/Ouroboros.Abstractions/Agent/MetaAI/WorldModel/IWorldModelEngine.cs
@@ -1,0 +1,85 @@
+// <copyright file="IWorldModelEngine.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Agent.MetaAI.WorldModel;
+
+using Ouroboros.Core.Monads;
+
+/// <summary>
+/// Main interface for world model learning and imagination-based planning.
+/// Enables model-based reinforcement learning through learned environment models.
+/// All operations return Result types for robust error handling.
+/// </summary>
+public interface IWorldModelEngine
+{
+    /// <summary>
+    /// Learns a world model from experience data (transitions).
+    /// </summary>
+    /// <param name="transitions">List of observed transitions from the environment.</param>
+    /// <param name="architecture">The model architecture to use.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing the learned world model or error message.</returns>
+    Task<Result<WorldModel, string>> LearnModelAsync(
+        List<Transition> transitions,
+        ModelArchitecture architecture,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Predicts the next state given current state and action using the learned model.
+    /// </summary>
+    /// <param name="currentState">The current state.</param>
+    /// <param name="action">The action to simulate.</param>
+    /// <param name="model">The world model to use for prediction.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing the predicted next state or error message.</returns>
+    Task<Result<State, string>> PredictNextStateAsync(
+        State currentState,
+        Action action,
+        WorldModel model,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Plans a sequence of actions using imagination (model-based planning).
+    /// Uses techniques like Monte Carlo Tree Search with the world model.
+    /// </summary>
+    /// <param name="initialState">The starting state for planning.</param>
+    /// <param name="goal">Natural language description of the goal.</param>
+    /// <param name="model">The world model to use for imagination.</param>
+    /// <param name="lookaheadDepth">How many steps to look ahead.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing the planned action sequence or error message.</returns>
+    Task<Result<Plan, string>> PlanInImaginationAsync(
+        State initialState,
+        string goal,
+        WorldModel model,
+        int lookaheadDepth,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Evaluates the quality of a world model against a test set.
+    /// </summary>
+    /// <param name="model">The world model to evaluate.</param>
+    /// <param name="testSet">Test transitions for evaluation.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing quality metrics or error message.</returns>
+    Task<Result<ModelQuality, string>> EvaluateModelAsync(
+        WorldModel model,
+        List<Transition> testSet,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generates synthetic experience by rolling out trajectories in the learned model.
+    /// Useful for data augmentation in model-based RL.
+    /// </summary>
+    /// <param name="model">The world model to use.</param>
+    /// <param name="startState">The starting state for trajectory generation.</param>
+    /// <param name="trajectoryLength">Number of steps to generate.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing synthetic transitions or error message.</returns>
+    Task<Result<List<Transition>, string>> GenerateSyntheticExperienceAsync(
+        WorldModel model,
+        State startState,
+        int trajectoryLength,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/NeuralSymbolic/INeuralSymbolicBridge.cs
+++ b/src/Ouroboros.Abstractions/Agent/NeuralSymbolic/INeuralSymbolicBridge.cs
@@ -1,0 +1,86 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Neural-Symbolic Bridge Interface
+// Bridges neural (LLM) and symbolic (MeTTa) reasoning
+// ==========================================================
+
+namespace Ouroboros.Agent.NeuralSymbolic;
+
+using Ouroboros.Agent.MetaAI;
+
+/// <summary>
+/// Interface for bridging neural and symbolic reasoning systems.
+/// Enables rule extraction, hybrid reasoning, and logical consistency checking.
+/// </summary>
+public interface INeuralSymbolicBridge
+{
+    /// <summary>
+    /// Extracts symbolic rules from learned skills.
+    /// </summary>
+    /// <param name="skill">The skill to extract rules from.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of extracted symbolic rules.</returns>
+    Task<Result<List<SymbolicRule>, string>> ExtractRulesFromSkillAsync(
+        Skill skill,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Converts natural language to MeTTa expressions.
+    /// </summary>
+    /// <param name="naturalLanguage">The natural language description.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Parsed MeTTa expression.</returns>
+    Task<Result<MeTTaExpression, string>> NaturalLanguageToMeTTaAsync(
+        string naturalLanguage,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Converts MeTTa expressions to natural language explanation.
+    /// </summary>
+    /// <param name="expression">The MeTTa expression.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Natural language explanation.</returns>
+    Task<Result<string, string>> MeTTaToNaturalLanguageAsync(
+        MeTTaExpression expression,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Performs symbolic reasoning with neural fallback.
+    /// </summary>
+    /// <param name="query">The reasoning query.</param>
+    /// <param name="mode">The reasoning mode to use.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Reasoning result with steps and confidence.</returns>
+    Task<Result<ReasoningResult, string>> HybridReasonAsync(
+        string query,
+        ReasoningMode mode = ReasoningMode.SymbolicFirst,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks logical consistency of a hypothesis.
+    /// </summary>
+    /// <param name="hypothesis">The hypothesis to check.</param>
+    /// <param name="knowledgeBase">The symbolic knowledge base to check against.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// Consistency report with conflicts and suggestions.
+    /// Note: LogicalConflict.Rule1 and Rule2 may be null when conflicts are detected 
+    /// through LLM analysis but specific conflicting rules cannot be identified.
+    /// </returns>
+    Task<Result<ConsistencyReport, string>> CheckConsistencyAsync(
+        MetaAI.Hypothesis hypothesis,
+        IReadOnlyList<SymbolicRule> knowledgeBase,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Grounds neural embeddings in symbolic concepts.
+    /// </summary>
+    /// <param name="conceptDescription">Description of the concept.</param>
+    /// <param name="embedding">Neural embedding vector.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Grounded concept with symbolic representation.</returns>
+    Task<Result<GroundedConcept, string>> GroundConceptAsync(
+        string conceptDescription,
+        float[] embedding,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/NeuralSymbolic/ISymbolicKnowledgeBase.cs
+++ b/src/Ouroboros.Abstractions/Agent/NeuralSymbolic/ISymbolicKnowledgeBase.cs
@@ -1,0 +1,53 @@
+using Ouroboros.Abstractions;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// ==========================================================
+// Symbolic Knowledge Base Interface
+// Manages symbolic rules and MeTTa reasoning
+// ==========================================================
+
+namespace Ouroboros.Agent.NeuralSymbolic;
+
+/// <summary>
+/// Interface for managing symbolic knowledge and executing MeTTa queries.
+/// </summary>
+public interface ISymbolicKnowledgeBase
+{
+    /// <summary>
+    /// Adds a symbolic rule to the knowledge base.
+    /// </summary>
+    /// <param name="rule">The rule to add.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Success or error.</returns>
+    Task<Result<Unit, string>> AddRuleAsync(SymbolicRule rule, CancellationToken ct = default);
+
+    /// <summary>
+    /// Queries rules matching a pattern.
+    /// </summary>
+    /// <param name="pattern">The pattern to match.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of matching rules.</returns>
+    Task<Result<List<SymbolicRule>, string>> QueryRulesAsync(string pattern, CancellationToken ct = default);
+
+    /// <summary>
+    /// Executes a MeTTa query against the knowledge base.
+    /// </summary>
+    /// <param name="query">The MeTTa query.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Query result as string.</returns>
+    Task<Result<string, string>> ExecuteMeTTaQueryAsync(string query, CancellationToken ct = default);
+
+    /// <summary>
+    /// Performs inference from a fact using rules in the knowledge base.
+    /// </summary>
+    /// <param name="fact">The starting fact.</param>
+    /// <param name="maxDepth">Maximum inference depth.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of inferred facts.</returns>
+    Task<Result<List<string>, string>> InferAsync(string fact, int maxDepth = 5, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the number of rules in the knowledge base.
+    /// </summary>
+    int RuleCount { get; }
+}

--- a/src/Ouroboros.Abstractions/Agent/TemporalReasoning/ITemporalReasoner.cs
+++ b/src/Ouroboros.Abstractions/Agent/TemporalReasoning/ITemporalReasoner.cs
@@ -1,0 +1,73 @@
+// <copyright file="ITemporalReasoner.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Agent.TemporalReasoning;
+
+/// <summary>
+/// Interface for temporal reasoning capabilities.
+/// Enables reasoning about time, sequences, causality, and temporal relationships between events.
+/// </summary>
+public interface ITemporalReasoner
+{
+    /// <summary>
+    /// Determines temporal relationship between two events.
+    /// </summary>
+    /// <param name="event1">First temporal event.</param>
+    /// <param name="event2">Second temporal event.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The temporal relation between the events or an error message.</returns>
+    Task<Result<TemporalRelation, string>> GetRelationAsync(
+        TemporalEvent event1,
+        TemporalEvent event2,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Queries events matching temporal constraints.
+    /// </summary>
+    /// <param name="query">Query parameters for filtering events.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Collection of matching temporal events or an error message.</returns>
+    Task<Result<IReadOnlyList<TemporalEvent>, string>> QueryEventsAsync(
+        TemporalQuery query,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Infers causal relationships from temporal patterns.
+    /// </summary>
+    /// <param name="events">Collection of temporal events to analyze.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Collection of inferred causal relations or an error message.</returns>
+    Task<Result<IReadOnlyList<CausalRelation>, string>> InferCausalityAsync(
+        IReadOnlyList<TemporalEvent> events,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Predicts future events based on temporal patterns.
+    /// </summary>
+    /// <param name="history">Historical temporal events to base predictions on.</param>
+    /// <param name="horizon">Time horizon for predictions.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Collection of predicted events or an error message.</returns>
+    Task<Result<IReadOnlyList<PredictedEvent>, string>> PredictFutureEventsAsync(
+        IReadOnlyList<TemporalEvent> history,
+        TimeSpan horizon,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Constructs a timeline from a set of events.
+    /// </summary>
+    /// <param name="events">Collection of temporal events to organize into a timeline.</param>
+    /// <returns>A constructed timeline or an error message.</returns>
+    Result<Timeline, string> ConstructTimeline(IReadOnlyList<TemporalEvent> events);
+
+    /// <summary>
+    /// Checks if a temporal constraint is satisfiable.
+    /// </summary>
+    /// <param name="constraints">Collection of temporal constraints to validate.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if constraints are satisfiable, false otherwise, or an error message.</returns>
+    Task<Result<bool, string>> CheckConstraintSatisfiabilityAsync(
+        IReadOnlyList<TemporalConstraint> constraints,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/TheoryOfMind/ITheoryOfMind.cs
+++ b/src/Ouroboros.Abstractions/Agent/TheoryOfMind/ITheoryOfMind.cs
@@ -1,0 +1,81 @@
+// <copyright file="ITheoryOfMind.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using Ouroboros.Domain.Embodied;
+using Unit = Ouroboros.Abstractions.Unit;
+
+namespace Ouroboros.Agent.TheoryOfMind;
+
+/// <summary>
+/// Interface for Theory of Mind capabilities.
+/// Enables agents to model other agents' beliefs, desires, and intentions.
+/// </summary>
+public interface ITheoryOfMind
+{
+    /// <summary>
+    /// Infers another agent's beliefs from observations.
+    /// </summary>
+    /// <param name="agentId">The ID of the agent to model</param>
+    /// <param name="observations">Recent observations of the agent</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing the inferred belief state or error message</returns>
+    Task<Result<BeliefState, string>> InferBeliefsAsync(
+        string agentId,
+        IReadOnlyList<AgentObservation> observations,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Predicts another agent's likely intention or goal.
+    /// </summary>
+    /// <param name="agentId">The ID of the agent to model</param>
+    /// <param name="beliefs">The agent's current belief state</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing the intention prediction or error message</returns>
+    Task<Result<IntentionPrediction, string>> PredictIntentionAsync(
+        string agentId,
+        BeliefState beliefs,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Predicts what action another agent will take next.
+    /// </summary>
+    /// <param name="agentId">The ID of the agent to model</param>
+    /// <param name="beliefs">The agent's current belief state</param>
+    /// <param name="availableActions">Actions available to the agent</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing the action prediction or error message</returns>
+    Task<Result<ActionPrediction, string>> PredictNextActionAsync(
+        string agentId,
+        BeliefState beliefs,
+        IReadOnlyList<EmbodiedAction> availableActions,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates the model of a specific agent based on new observation.
+    /// </summary>
+    /// <param name="agentId">The ID of the agent to update</param>
+    /// <param name="observation">The new observation</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing Unit on success or error message on failure</returns>
+    Task<Result<Unit, string>> UpdateAgentModelAsync(
+        string agentId,
+        AgentObservation observation,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the current model of a specific agent.
+    /// </summary>
+    /// <param name="agentId">The ID of the agent to retrieve</param>
+    /// <returns>The agent model if it exists, null otherwise</returns>
+    AgentModel? GetAgentModel(string agentId);
+
+    /// <summary>
+    /// Evaluates how well the agent understands another agent.
+    /// Returns a confidence score based on observation history and model quality.
+    /// </summary>
+    /// <param name="agentId">The ID of the agent to evaluate</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Confidence score (0.0 to 1.0)</returns>
+    Task<double> GetModelConfidenceAsync(string agentId, CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Agent/WorldModel/IWorldModel.cs
+++ b/src/Ouroboros.Abstractions/Agent/WorldModel/IWorldModel.cs
@@ -1,0 +1,73 @@
+// <copyright file="IWorldModel.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using Ouroboros.Abstractions;
+
+namespace Ouroboros.Agent.WorldModel;
+
+using Ouroboros.Core.Monads;
+using Ouroboros.Domain.Embodied;
+
+/// <summary>
+/// Interface for predictive world models enabling model-based planning.
+/// Allows agents to simulate future states and plan action sequences.
+/// </summary>
+public interface IWorldModel
+{
+    /// <summary>
+    /// Predicts next state given current state and action.
+    /// </summary>
+    /// <param name="currentState">Current sensor state</param>
+    /// <param name="action">Action to simulate</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing predicted state or error</returns>
+    Task<Result<PredictedState, string>> PredictAsync(
+        SensorState currentState,
+        EmbodiedAction action,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates world model from observed transitions.
+    /// </summary>
+    /// <param name="transitions">List of observed state transitions</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result indicating success or error</returns>
+    Task<Result<Unit, string>> UpdateFromExperienceAsync(
+        IReadOnlyList<EmbodiedTransition> transitions,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Plans action sequence using model-based search (e.g., MCTS, beam search).
+    /// </summary>
+    /// <param name="current">Current sensor state</param>
+    /// <param name="goal">Goal description</param>
+    /// <param name="horizon">Planning horizon (number of steps)</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing planned action sequence or error</returns>
+    Task<Result<List<EmbodiedAction>, string>> PlanWithModelAsync(
+        SensorState current,
+        string goal,
+        int horizon = 10,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns model uncertainty/epistemic confidence for given state-action.
+    /// </summary>
+    /// <param name="state">Current state</param>
+    /// <param name="action">Action to evaluate</param>
+    /// <returns>Uncertainty value (0-1, where 1 is high uncertainty)</returns>
+    Task<double> GetUncertaintyAsync(SensorState state, EmbodiedAction action);
+
+    /// <summary>
+    /// Simulates a full trajectory given initial state and action sequence.
+    /// </summary>
+    /// <param name="initialState">Initial sensor state</param>
+    /// <param name="actions">Sequence of actions to simulate</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing predicted states or error</returns>
+    Task<Result<List<PredictedState>, string>> SimulateTrajectoryAsync(
+        SensorState initialState,
+        IReadOnlyList<EmbodiedAction> actions,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/GlobalUsings.cs
+++ b/src/Ouroboros.Abstractions/GlobalUsings.cs
@@ -1,0 +1,25 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+// System imports
+global using System;
+global using System.Collections.Concurrent;
+global using System.Collections.Generic;
+global using System.Collections.Immutable;
+global using System.Diagnostics;
+global using System.IO;
+global using System.Linq;
+global using System.Net.Http;
+global using System.Reflection;
+global using System.Text;
+global using System.Text.Json;
+global using System.Text.RegularExpressions;
+global using System.Threading;
+global using System.Threading.Tasks;
+// Foundation layer
+global using Ouroboros.Core.Monads;
+global using Ouroboros.Domain;
+global using Ouroboros.Domain.Autonomous;
+global using Ouroboros.Domain.Embodied;
+global using Ouroboros.Domain.Events;
+global using Ouroboros.Domain.States;
+global using Ouroboros.Domain.Vectors;
+global using Ouroboros.Tools;

--- a/src/Ouroboros.Abstractions/Network/Persistence/IGraphPersistence.cs
+++ b/src/Ouroboros.Abstractions/Network/Persistence/IGraphPersistence.cs
@@ -1,0 +1,44 @@
+// <copyright file="IGraphPersistence.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Network.Persistence;
+
+/// <summary>
+/// Defines the contract for persisting Merkle-DAG nodes and edges to durable storage.
+/// Implements an append-only Write-Ahead Log pattern for crash recovery.
+/// </summary>
+public interface IGraphPersistence : IAsyncDisposable
+{
+    /// <summary>
+    /// Appends a node addition to the Write-Ahead Log.
+    /// </summary>
+    /// <param name="node">The node to persist.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task AppendNodeAsync(MonadNode node, CancellationToken ct = default);
+
+    /// <summary>
+    /// Appends an edge addition to the Write-Ahead Log.
+    /// </summary>
+    /// <param name="edge">The edge to persist.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task AppendEdgeAsync(TransitionEdge edge, CancellationToken ct = default);
+
+    /// <summary>
+    /// Flushes all pending writes to durable storage.
+    /// Ensures durability for all previously appended entries.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous flush operation.</returns>
+    Task FlushAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Replays all entries from the Write-Ahead Log in chronological order.
+    /// Used during recovery to rebuild the in-memory DAG state.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An async enumerable of WAL entries.</returns>
+    IAsyncEnumerable<WalEntry> ReplayAsync(CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Ouroboros.Abstractions.csproj
+++ b/src/Ouroboros.Abstractions/Ouroboros.Abstractions.csproj
@@ -6,4 +6,14 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\Ouroboros.Core\Ouroboros.Core.csproj" />
+        <ProjectReference Include="..\Ouroboros.Domain\Ouroboros.Domain.csproj" />
+        <ProjectReference Include="..\Ouroboros.Tools\Ouroboros.Tools.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.Reactive" Version="6.1.0" />
+    </ItemGroup>
+
 </Project>

--- a/src/Ouroboros.Abstractions/Providers/Docker/IDockerMcpClient.cs
+++ b/src/Ouroboros.Abstractions/Providers/Docker/IDockerMcpClient.cs
@@ -1,0 +1,128 @@
+// <copyright file="IDockerMcpClient.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Providers.Docker;
+
+/// <summary>
+/// Interface for Docker Engine MCP client operations.
+/// Provides methods for managing containers, images, volumes, and networks.
+/// </summary>
+public interface IDockerMcpClient
+{
+    /// <summary>
+    /// Lists running containers (optionally all).
+    /// </summary>
+    /// <param name="all">If true, include stopped containers.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of container info or error.</returns>
+    Task<Result<IReadOnlyList<DockerContainerInfo>, string>> ListContainersAsync(
+        bool all = false,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets details of a specific container.
+    /// </summary>
+    /// <param name="containerId">Container ID or name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing container details or error.</returns>
+    Task<Result<DockerContainerInfo, string>> InspectContainerAsync(
+        string containerId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets log output from a container.
+    /// </summary>
+    /// <param name="containerId">Container ID or name.</param>
+    /// <param name="tail">Number of lines from the end (default: 100).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing log text or error.</returns>
+    Task<Result<string, string>> GetContainerLogsAsync(
+        string containerId,
+        int tail = 100,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts a stopped container.
+    /// </summary>
+    /// <param name="containerId">Container ID or name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating success or error.</returns>
+    Task<Result<string, string>> StartContainerAsync(
+        string containerId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Stops a running container.
+    /// </summary>
+    /// <param name="containerId">Container ID or name.</param>
+    /// <param name="timeoutSeconds">Seconds to wait before killing (default: 10).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating success or error.</returns>
+    Task<Result<string, string>> StopContainerAsync(
+        string containerId,
+        int timeoutSeconds = 10,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a stopped container.
+    /// </summary>
+    /// <param name="containerId">Container ID or name.</param>
+    /// <param name="force">Force removal of a running container.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating success or error.</returns>
+    Task<Result<string, string>> RemoveContainerAsync(
+        string containerId,
+        bool force = false,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists Docker images on the host.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of image info or error.</returns>
+    Task<Result<IReadOnlyList<DockerImageInfo>, string>> ListImagesAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Pulls an image from a registry.
+    /// </summary>
+    /// <param name="image">Image reference (e.g., "nginx:latest").</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating success or error.</returns>
+    Task<Result<string, string>> PullImageAsync(
+        string image,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists Docker networks.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of network info or error.</returns>
+    Task<Result<IReadOnlyList<DockerNetworkInfo>, string>> ListNetworksAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists Docker volumes.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of volume info or error.</returns>
+    Task<Result<IReadOnlyList<DockerVolumeInfo>, string>> ListVolumesAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Creates and starts a new container from an image.
+    /// </summary>
+    /// <param name="image">The image to use.</param>
+    /// <param name="name">Optional container name.</param>
+    /// <param name="ports">Port mappings (host:container), e.g. ["8080:80"].</param>
+    /// <param name="envVars">Environment variables (KEY=VALUE).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing the container ID or error.</returns>
+    Task<Result<string, string>> RunContainerAsync(
+        string image,
+        string? name = null,
+        IReadOnlyList<string>? ports = null,
+        IReadOnlyList<string>? envVars = null,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Providers/DuckDuckGo/IDuckDuckGoMcpClient.cs
+++ b/src/Ouroboros.Abstractions/Providers/DuckDuckGo/IDuckDuckGoMcpClient.cs
@@ -1,0 +1,50 @@
+// <copyright file="IDuckDuckGoMcpClient.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Providers.DuckDuckGo;
+
+/// <summary>
+/// Interface for DuckDuckGo MCP client operations.
+/// Provides web search, news search, and instant answers — no API key required.
+/// </summary>
+public interface IDuckDuckGoMcpClient
+{
+    /// <summary>
+    /// Performs a web search using DuckDuckGo.
+    /// </summary>
+    /// <param name="query">The search query.</param>
+    /// <param name="maxResults">Maximum number of results (default: 10).</param>
+    /// <param name="region">Region code (e.g., "us-en", "de-de"). Default: "wt-wt" (no region).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing search results or error.</returns>
+    Task<Result<IReadOnlyList<DuckDuckGoSearchResult>, string>> SearchAsync(
+        string query,
+        int maxResults = 10,
+        string region = "wt-wt",
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Performs a news search using DuckDuckGo.
+    /// </summary>
+    /// <param name="query">The search query.</param>
+    /// <param name="maxResults">Maximum number of results (default: 10).</param>
+    /// <param name="region">Region code. Default: "wt-wt".</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing news results or error.</returns>
+    Task<Result<IReadOnlyList<DuckDuckGoNewsResult>, string>> SearchNewsAsync(
+        string query,
+        int maxResults = 10,
+        string region = "wt-wt",
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets an instant answer from DuckDuckGo (abstract / knowledge panel).
+    /// </summary>
+    /// <param name="query">The search query.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing instant answer or error.</returns>
+    Task<Result<DuckDuckGoInstantAnswer, string>> InstantAnswerAsync(
+        string query,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Providers/Firecrawl/IFirecrawlMcpClient.cs
+++ b/src/Ouroboros.Abstractions/Providers/Firecrawl/IFirecrawlMcpClient.cs
@@ -1,0 +1,80 @@
+// <copyright file="IFirecrawlMcpClient.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Providers.Firecrawl;
+
+/// <summary>
+/// Interface for Firecrawl MCP client operations.
+/// Provides methods for web scraping, crawling, and content extraction.
+/// </summary>
+public interface IFirecrawlMcpClient
+{
+    /// <summary>
+    /// Scrapes a single URL and returns clean markdown content.
+    /// </summary>
+    /// <param name="url">The URL to scrape.</param>
+    /// <param name="options">Optional scrape options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing scraped content or error.</returns>
+    Task<Result<FirecrawlScrapeResult, string>> ScrapeAsync(
+        string url,
+        FirecrawlScrapeOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Crawls a website starting from a URL and returns content from multiple pages.
+    /// </summary>
+    /// <param name="url">The starting URL.</param>
+    /// <param name="options">Optional crawl options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing crawl job ID or error.</returns>
+    Task<Result<string, string>> CrawlAsync(
+        string url,
+        FirecrawlCrawlOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks the status of a crawl job.
+    /// </summary>
+    /// <param name="jobId">The crawl job ID.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing crawl status or error.</returns>
+    Task<Result<FirecrawlCrawlStatus, string>> GetCrawlStatusAsync(
+        string jobId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Searches the web and returns scraped results.
+    /// </summary>
+    /// <param name="query">The search query.</param>
+    /// <param name="maxResults">Maximum number of results (default: 5).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing search results or error.</returns>
+    Task<Result<IReadOnlyList<FirecrawlSearchResult>, string>> SearchAsync(
+        string query,
+        int maxResults = 5,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Extracts structured data from a URL using an LLM-based extraction schema.
+    /// </summary>
+    /// <param name="url">The URL to extract from.</param>
+    /// <param name="schema">JSON schema describing the data to extract.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing extracted JSON or error.</returns>
+    Task<Result<string, string>> ExtractAsync(
+        string url,
+        string schema,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Maps a website to discover all accessible URLs without scraping content.
+    /// </summary>
+    /// <param name="url">The starting URL.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of discovered URLs or error.</returns>
+    Task<Result<IReadOnlyList<string>, string>> MapAsync(
+        string url,
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Providers/Kubernetes/IKubernetesMcpClient.cs
+++ b/src/Ouroboros.Abstractions/Providers/Kubernetes/IKubernetesMcpClient.cs
@@ -1,0 +1,122 @@
+// <copyright file="IKubernetesMcpClient.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Providers.Kubernetes;
+
+/// <summary>
+/// Interface for Kubernetes MCP client operations.
+/// Provides methods for managing pods, deployments, services, and reading logs.
+/// </summary>
+public interface IKubernetesMcpClient
+{
+    /// <summary>
+    /// Lists pods in the specified namespace.
+    /// </summary>
+    /// <param name="ns">The namespace (default: "default").</param>
+    /// <param name="labelSelector">Optional label selector to filter pods.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of pod info or error.</returns>
+    Task<Result<IReadOnlyList<KubernetesPodInfo>, string>> ListPodsAsync(
+        string ns = "default",
+        string? labelSelector = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets details of a specific pod.
+    /// </summary>
+    /// <param name="name">The pod name.</param>
+    /// <param name="ns">The namespace (default: "default").</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing pod details or error.</returns>
+    Task<Result<KubernetesPodInfo, string>> GetPodAsync(
+        string name,
+        string ns = "default",
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Reads log output from a pod.
+    /// </summary>
+    /// <param name="podName">The pod name.</param>
+    /// <param name="ns">The namespace (default: "default").</param>
+    /// <param name="container">Optional container name (for multi-container pods).</param>
+    /// <param name="tailLines">Number of most recent lines to return (default: 100).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing log text or error.</returns>
+    Task<Result<string, string>> GetPodLogsAsync(
+        string podName,
+        string ns = "default",
+        string? container = null,
+        int tailLines = 100,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists deployments in the specified namespace.
+    /// </summary>
+    /// <param name="ns">The namespace (default: "default").</param>
+    /// <param name="labelSelector">Optional label selector.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of deployments or error.</returns>
+    Task<Result<IReadOnlyList<KubernetesDeploymentInfo>, string>> ListDeploymentsAsync(
+        string ns = "default",
+        string? labelSelector = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Scales a deployment to the specified replica count.
+    /// </summary>
+    /// <param name="deploymentName">The deployment name.</param>
+    /// <param name="replicas">Desired replica count.</param>
+    /// <param name="ns">The namespace (default: "default").</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing updated deployment info or error.</returns>
+    Task<Result<KubernetesDeploymentInfo, string>> ScaleDeploymentAsync(
+        string deploymentName,
+        int replicas,
+        string ns = "default",
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists services in the specified namespace.
+    /// </summary>
+    /// <param name="ns">The namespace (default: "default").</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of services or error.</returns>
+    Task<Result<IReadOnlyList<KubernetesServiceInfo>, string>> ListServicesAsync(
+        string ns = "default",
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists namespaces in the cluster.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing list of namespace names or error.</returns>
+    Task<Result<IReadOnlyList<string>, string>> ListNamespacesAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Applies a YAML/JSON manifest to the cluster.
+    /// </summary>
+    /// <param name="manifest">The manifest content (JSON or YAML).</param>
+    /// <param name="ns">The namespace (default: "default").</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result containing the resource name created/updated or error.</returns>
+    Task<Result<string, string>> ApplyManifestAsync(
+        string manifest,
+        string ns = "default",
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes a resource by kind and name.
+    /// </summary>
+    /// <param name="kind">The resource kind (e.g., "pod", "deployment", "service").</param>
+    /// <param name="name">The resource name.</param>
+    /// <param name="ns">The namespace (default: "default").</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating success or error.</returns>
+    Task<Result<string, string>> DeleteResourceAsync(
+        string kind,
+        string name,
+        string ns = "default",
+        CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Providers/LoadBalancing/IProviderLoadBalancer.cs
+++ b/src/Ouroboros.Abstractions/Providers/LoadBalancing/IProviderLoadBalancer.cs
@@ -1,0 +1,110 @@
+// <copyright file="IProviderLoadBalancer.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Ouroboros.Providers.LoadBalancing;
+
+/// <summary>
+/// Health status of a provider including performance metrics and availability.
+/// </summary>
+public sealed record ProviderHealthStatus(
+    string ProviderId,
+    bool IsHealthy,
+    double SuccessRate,
+    double AverageLatencyMs,
+    int ConsecutiveFailures,
+    DateTime? LastFailureTime,
+    DateTime? CooldownUntil,
+    int TotalRequests,
+    int SuccessfulRequests,
+    DateTime LastChecked)
+{
+    /// <summary>
+    /// Gets a value indicating whether the provider is in cooldown (rate limited).
+    /// </summary>
+    public bool IsInCooldown => CooldownUntil.HasValue && CooldownUntil.Value > DateTime.UtcNow;
+
+    /// <summary>
+    /// Calculates composite health score (0.0 to 1.0).
+    /// </summary>
+    public double HealthScore
+    {
+        get
+        {
+            if (!IsHealthy || IsInCooldown) return 0.0;
+
+            // Weight success rate more heavily, normalize latency
+            double latencyScore = Math.Max(0, 1.0 - (AverageLatencyMs / 10000.0));
+            return (SuccessRate * 0.7) + (latencyScore * 0.3);
+        }
+    }
+}
+
+/// <summary>
+/// Result of provider selection including the selected provider and reasoning.
+/// </summary>
+public sealed record ProviderSelectionResult<T>(
+    T Provider,
+    string ProviderId,
+    string Strategy,
+    string Reason,
+    ProviderHealthStatus Health);
+
+/// <summary>
+/// Interface for load balancing across multiple provider instances.
+/// Implements intelligent routing to prevent rate limiting and maximize availability.
+/// </summary>
+/// <typeparam name="T">Type of provider being load balanced.</typeparam>
+public interface IProviderLoadBalancer<T>
+{
+    /// <summary>
+    /// Gets the currently configured selection strategy.
+    /// </summary>
+    IProviderSelectionStrategy Strategy { get; }
+
+    /// <summary>
+    /// Gets the current health status of all providers.
+    /// </summary>
+    IReadOnlyDictionary<string, ProviderHealthStatus> GetHealthStatus();
+
+    /// <summary>
+    /// Selects the next provider based on the configured strategy and health metrics.
+    /// </summary>
+    /// <param name="context">Optional context for selection decisions.</param>
+    /// <returns>Result containing selected provider or error.</returns>
+    Task<Result<ProviderSelectionResult<T>, string>> SelectProviderAsync(
+        Dictionary<string, object>? context = null);
+
+    /// <summary>
+    /// Records execution metrics for a provider after a request completes.
+    /// </summary>
+    /// <param name="providerId">Unique identifier of the provider.</param>
+    /// <param name="latencyMs">Request latency in milliseconds.</param>
+    /// <param name="success">Whether the request succeeded.</param>
+    /// <param name="wasRateLimited">Whether the request was rate limited (429).</param>
+    void RecordExecution(string providerId, double latencyMs, bool success, bool wasRateLimited = false);
+
+    /// <summary>
+    /// Manually marks a provider as unhealthy (circuit breaker).
+    /// </summary>
+    /// <param name="providerId">Unique identifier of the provider.</param>
+    /// <param name="cooldownDuration">Optional cooldown duration.</param>
+    void MarkProviderUnhealthy(string providerId, TimeSpan? cooldownDuration = null);
+
+    /// <summary>
+    /// Manually marks a provider as healthy.
+    /// </summary>
+    /// <param name="providerId">Unique identifier of the provider.</param>
+    void MarkProviderHealthy(string providerId);
+
+    /// <summary>
+    /// Gets the total number of registered providers.
+    /// </summary>
+    int ProviderCount { get; }
+
+    /// <summary>
+    /// Gets the number of currently healthy providers.
+    /// </summary>
+    int HealthyProviderCount { get; }
+}

--- a/src/Ouroboros.Abstractions/Providers/LoadBalancing/IProviderSelectionStrategy.cs
+++ b/src/Ouroboros.Abstractions/Providers/LoadBalancing/IProviderSelectionStrategy.cs
@@ -1,0 +1,26 @@
+// <copyright file="IProviderSelectionStrategy.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Ouroboros.Providers.LoadBalancing;
+
+/// <summary>
+/// Strategy interface for selecting a provider from a pool of healthy providers.
+/// Implements the Strategy design pattern for pluggable provider selection algorithms.
+/// </summary>
+public interface IProviderSelectionStrategy
+{
+    /// <summary>
+    /// Gets the name of this strategy.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Selects a provider from the list of healthy providers based on this strategy's algorithm.
+    /// </summary>
+    /// <param name="healthyProviders">List of provider IDs that are healthy and available.</param>
+    /// <param name="healthStatus">Dictionary of health status for all providers.</param>
+    /// <returns>The ID of the selected provider.</returns>
+    string SelectProvider(List<string> healthyProviders, IReadOnlyDictionary<string, ProviderHealthStatus> healthStatus);
+}

--- a/src/Ouroboros.Abstractions/Providers/SpeechToText/ISpeechToTextService.cs
+++ b/src/Ouroboros.Abstractions/Providers/SpeechToText/ISpeechToTextService.cs
@@ -1,0 +1,127 @@
+// <copyright file="ISpeechToTextService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Providers.SpeechToText;
+
+/// <summary>
+/// Represents the result of a speech-to-text transcription.
+/// </summary>
+/// <param name="Text">The transcribed text.</param>
+/// <param name="Language">The detected or specified language.</param>
+/// <param name="Duration">Duration of the audio in seconds.</param>
+/// <param name="Segments">Optional word/segment-level timestamps.</param>
+public sealed record TranscriptionResult(
+    string Text,
+    string? Language = null,
+    double? Duration = null,
+    IReadOnlyList<TranscriptionSegment>? Segments = null);
+
+/// <summary>
+/// Represents a segment of transcribed audio with timing information.
+/// </summary>
+/// <param name="Text">The text of this segment.</param>
+/// <param name="Start">Start time in seconds.</param>
+/// <param name="End">End time in seconds.</param>
+/// <param name="Confidence">Optional confidence score (0-1).</param>
+public sealed record TranscriptionSegment(
+    string Text,
+    double Start,
+    double End,
+    double? Confidence = null);
+
+/// <summary>
+/// Configuration options for speech-to-text transcription.
+/// </summary>
+/// <param name="Language">Optional language hint (ISO 639-1 code, e.g., "en", "de", "fr").</param>
+/// <param name="ResponseFormat">Response format: "text", "json", "verbose_json", "srt", "vtt".</param>
+/// <param name="Temperature">Sampling temperature (0-1). Lower = more deterministic.</param>
+/// <param name="TimestampGranularity">Granularity for timestamps: "word", "segment", or null.</param>
+/// <param name="Prompt">Optional prompt to guide the transcription style.</param>
+public sealed record TranscriptionOptions(
+    string? Language = null,
+    string ResponseFormat = "json",
+    double? Temperature = null,
+    string? TimestampGranularity = null,
+    string? Prompt = null);
+
+/// <summary>
+/// Defines the contract for speech-to-text transcription services.
+/// Supports various audio formats and providers (OpenAI Whisper, Azure, local Whisper, etc.).
+/// </summary>
+public interface ISpeechToTextService
+{
+    /// <summary>
+    /// Gets the name of the speech-to-text provider.
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Gets the supported audio formats.
+    /// </summary>
+    IReadOnlyList<string> SupportedFormats { get; }
+
+    /// <summary>
+    /// Gets the maximum audio file size in bytes.
+    /// </summary>
+    long MaxFileSizeBytes { get; }
+
+    /// <summary>
+    /// Transcribes audio from a file path.
+    /// </summary>
+    /// <param name="filePath">Path to the audio file.</param>
+    /// <param name="options">Optional transcription options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The transcription result.</returns>
+    Task<Result<TranscriptionResult, string>> TranscribeFileAsync(
+        string filePath,
+        TranscriptionOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Transcribes audio from a stream.
+    /// </summary>
+    /// <param name="audioStream">The audio stream.</param>
+    /// <param name="fileName">The file name (used to determine format).</param>
+    /// <param name="options">Optional transcription options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The transcription result.</returns>
+    Task<Result<TranscriptionResult, string>> TranscribeStreamAsync(
+        Stream audioStream,
+        string fileName,
+        TranscriptionOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Transcribes audio from a byte array.
+    /// </summary>
+    /// <param name="audioData">The audio data bytes.</param>
+    /// <param name="fileName">The file name (used to determine format).</param>
+    /// <param name="options">Optional transcription options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The transcription result.</returns>
+    Task<Result<TranscriptionResult, string>> TranscribeBytesAsync(
+        byte[] audioData,
+        string fileName,
+        TranscriptionOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Translates audio to English (if supported by the provider).
+    /// </summary>
+    /// <param name="filePath">Path to the audio file.</param>
+    /// <param name="options">Optional transcription options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The translation result in English.</returns>
+    Task<Result<TranscriptionResult, string>> TranslateToEnglishAsync(
+        string filePath,
+        TranscriptionOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks if the service is available and properly configured.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if the service is available.</returns>
+    Task<bool> IsAvailableAsync(CancellationToken ct = default);
+}

--- a/src/Ouroboros.Abstractions/Providers/SpeechToText/IStreamingSttService.cs
+++ b/src/Ouroboros.Abstractions/Providers/SpeechToText/IStreamingSttService.cs
@@ -1,0 +1,241 @@
+// <copyright file="IStreamingSttService.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// </copyright>
+
+using System.Reactive.Linq;
+
+namespace Ouroboros.Providers.SpeechToText;
+
+/// <summary>
+/// Audio chunk for streaming speech-to-text.
+/// </summary>
+/// <param name="Data">Raw audio data.</param>
+/// <param name="Format">Audio format (e.g., "pcm16", "wav").</param>
+/// <param name="SampleRate">Sample rate in Hz.</param>
+/// <param name="Channels">Number of audio channels (1 for mono, 2 for stereo).</param>
+/// <param name="IsFinal">Whether this is the final chunk in a recording session.</param>
+public sealed record AudioChunk(
+    byte[] Data,
+    string Format,
+    int SampleRate,
+    int Channels = 1,
+    bool IsFinal = false);
+
+/// <summary>
+/// Transcription event for streaming STT with partial/final distinction.
+/// </summary>
+/// <param name="Text">The transcribed text (may be partial).</param>
+/// <param name="IsFinal">Whether this is a final result (stable) or interim (may change).</param>
+/// <param name="Confidence">Confidence score (0.0-1.0).</param>
+/// <param name="Offset">Time offset from start of audio.</param>
+/// <param name="Duration">Duration of this transcription segment.</param>
+/// <param name="Language">Detected language code.</param>
+public sealed record TranscriptionEvent(
+    string Text,
+    bool IsFinal,
+    double Confidence,
+    TimeSpan Offset,
+    TimeSpan Duration,
+    string? Language = null);
+
+/// <summary>
+/// Voice activity detection event.
+/// </summary>
+/// <param name="Activity">The type of voice activity detected.</param>
+/// <param name="Timestamp">When the activity was detected.</param>
+/// <param name="Confidence">Confidence in the detection (0.0-1.0).</param>
+public sealed record VoiceActivityEvent(
+    VoiceActivity Activity,
+    DateTimeOffset Timestamp,
+    double Confidence = 1.0);
+
+/// <summary>
+/// Types of voice activity.
+/// </summary>
+public enum VoiceActivity
+{
+    /// <summary>Speech has started.</summary>
+    SpeechStart,
+
+    /// <summary>Speech has ended.</summary>
+    SpeechEnd,
+
+    /// <summary>Silence/no speech detected.</summary>
+    Silence,
+
+    /// <summary>Background noise detected (no speech).</summary>
+    Noise,
+}
+
+/// <summary>
+/// Configuration for streaming transcription.
+/// </summary>
+/// <param name="Language">Language hint (ISO 639-1 code).</param>
+/// <param name="EnableInterimResults">Whether to emit partial/interim results.</param>
+/// <param name="PunctuationMode">Punctuation mode: "auto", "none", "explicit".</param>
+/// <param name="ProfanityFilter">Whether to filter profanity.</param>
+/// <param name="SpeakerDiarization">Whether to identify different speakers.</param>
+/// <param name="MaxSpeakers">Maximum number of speakers to identify.</param>
+/// <param name="ModelSize">Model size hint: "tiny", "base", "small", "medium", "large".</param>
+public sealed record StreamingTranscriptionOptions(
+    string? Language = null,
+    bool EnableInterimResults = true,
+    string PunctuationMode = "auto",
+    bool ProfanityFilter = false,
+    bool SpeakerDiarization = false,
+    int MaxSpeakers = 2,
+    string ModelSize = "base");
+
+/// <summary>
+/// Extended STT interface that supports reactive streaming transcription.
+/// Enables real-time voice input processing.
+/// </summary>
+public interface IStreamingSttService : ISpeechToTextService
+{
+    /// <summary>
+    /// Creates a continuous transcription stream from audio chunks.
+    /// Emits partial results as speech is recognized in real-time.
+    /// </summary>
+    /// <param name="audioStream">Observable of audio chunks.</param>
+    /// <param name="options">Streaming transcription options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Observable of transcription events (partial and final).</returns>
+    IObservable<TranscriptionEvent> StreamTranscription(
+        IObservable<AudioChunk> audioStream,
+        StreamingTranscriptionOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Voice activity detection stream - detects speech start/end events.
+    /// Useful for determining when to start/stop recording.
+    /// </summary>
+    /// <param name="audioStream">Observable of audio chunks.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Observable of voice activity events.</returns>
+    IObservable<VoiceActivityEvent> DetectVoiceActivity(
+        IObservable<AudioChunk> audioStream,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts a streaming transcription session that can be fed audio chunks.
+    /// Returns a session that can be used to push audio and receive results.
+    /// </summary>
+    /// <param name="options">Streaming transcription options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A streaming session for interactive transcription.</returns>
+    Task<IStreamingTranscriptionSession> StartStreamingSessionAsync(
+        StreamingTranscriptionOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets whether streaming transcription is supported by this provider.
+    /// </summary>
+    bool SupportsStreaming { get; }
+
+    /// <summary>
+    /// Gets whether voice activity detection is supported.
+    /// </summary>
+    bool SupportsVoiceActivityDetection { get; }
+}
+
+/// <summary>
+/// A streaming transcription session for interactive audio input.
+/// </summary>
+public interface IStreamingTranscriptionSession : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the observable stream of transcription results.
+    /// </summary>
+    IObservable<TranscriptionEvent> Results { get; }
+
+    /// <summary>
+    /// Gets the observable stream of voice activity events.
+    /// </summary>
+    IObservable<VoiceActivityEvent> VoiceActivity { get; }
+
+    /// <summary>
+    /// Pushes an audio chunk to the transcription session.
+    /// </summary>
+    /// <param name="chunk">The audio chunk to process.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task PushAudioAsync(AudioChunk chunk, CancellationToken ct = default);
+
+    /// <summary>
+    /// Signals that no more audio will be sent, triggering final processing.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    Task EndAudioAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the accumulated final transcription text.
+    /// </summary>
+    string AccumulatedText { get; }
+
+    /// <summary>
+    /// Gets whether the session is currently active.
+    /// </summary>
+    bool IsActive { get; }
+
+    /// <summary>
+    /// Resets the session for a new transcription.
+    /// </summary>
+    void Reset();
+}
+
+/// <summary>
+/// Extension methods for streaming STT services.
+/// </summary>
+public static class StreamingSttExtensions
+{
+    /// <summary>
+    /// Filters a transcription stream to only final results.
+    /// </summary>
+    /// <param name="stream">The transcription event stream.</param>
+    /// <returns>Observable of only final transcription events.</returns>
+    public static IObservable<TranscriptionEvent> FinalResultsOnly(
+        this IObservable<TranscriptionEvent> stream)
+    {
+        return System.Reactive.Linq.Observable
+            .Where(stream, e => e.IsFinal);
+    }
+
+    /// <summary>
+    /// Extracts just the text from transcription events.
+    /// </summary>
+    /// <param name="stream">The transcription event stream.</param>
+    /// <returns>Observable of transcribed text strings.</returns>
+    public static IObservable<string> TextOnly(
+        this IObservable<TranscriptionEvent> stream)
+    {
+        return System.Reactive.Linq.Observable.Select(stream, e => e.Text)
+            .Where(static text => !string.IsNullOrWhiteSpace(text));
+    }
+
+    /// <summary>
+    /// Filters voice activity to speech boundaries (start and end only).
+    /// </summary>
+    /// <param name="stream">The voice activity stream.</param>
+    /// <returns>Observable of speech start/end events only.</returns>
+    public static IObservable<VoiceActivityEvent> SpeechBoundariesOnly(
+        this IObservable<VoiceActivityEvent> stream)
+    {
+        return System.Reactive.Linq.Observable.Where(
+            stream,
+            static e => e.Activity is VoiceActivity.SpeechStart or VoiceActivity.SpeechEnd);
+    }
+
+    /// <summary>
+    /// Detects speech segments between start and end events.
+    /// </summary>
+    /// <param name="stream">The voice activity stream.</param>
+    /// <returns>Observable of speech segment durations.</returns>
+    public static IObservable<TimeSpan> SpeechSegmentDurations(
+        this IObservable<VoiceActivityEvent> stream)
+    {
+        return System.Reactive.Linq.Observable.Buffer(stream.SpeechBoundariesOnly(), 2)
+            .Where(static buffer => buffer.Count == 2 &&
+                             buffer[0].Activity == VoiceActivity.SpeechStart &&
+                             buffer[1].Activity == VoiceActivity.SpeechEnd)
+            .Select(static buffer => buffer[1].Timestamp - buffer[0].Timestamp);
+    }
+}

--- a/src/Ouroboros.Abstractions/Providers/TextToSpeech/IStreamingTtsService.cs
+++ b/src/Ouroboros.Abstractions/Providers/TextToSpeech/IStreamingTtsService.cs
@@ -1,0 +1,190 @@
+// <copyright file="IStreamingTtsService.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Providers.TextToSpeech;
+
+/// <summary>
+/// A chunk of synthesized audio with metadata for streaming TTS.
+/// </summary>
+/// <param name="AudioData">The raw audio data.</param>
+/// <param name="Format">The audio format (e.g., "pcm16", "mp3", "wav").</param>
+/// <param name="DurationSeconds">Duration of this chunk in seconds.</param>
+/// <param name="Text">The text this chunk represents (for debugging/display).</param>
+/// <param name="IsSentenceEnd">Indicates a natural pause point (sentence boundary).</param>
+/// <param name="IsComplete">True if this is the final chunk.</param>
+public sealed record SpeechChunk(
+    byte[] AudioData,
+    string Format,
+    double DurationSeconds,
+    string? Text = null,
+    bool IsSentenceEnd = false,
+    bool IsComplete = false);
+
+/// <summary>
+/// Extended TTS interface that supports reactive streaming synthesis.
+/// Enables real-time voice output as LLM generates text.
+/// </summary>
+public interface IStreamingTtsService : ITextToSpeechService
+{
+    /// <summary>
+    /// Creates a reactive stream that consumes text chunks and produces audio chunks.
+    /// Perfect for piping LLM streaming output directly to voice synthesis.
+    /// </summary>
+    /// <remarks>
+    /// This method buffers incoming text into sentence-sized chunks for natural
+    /// TTS prosody, then synthesizes each sentence and emits the audio.
+    /// </remarks>
+    /// <param name="textStream">Observable of text chunks to synthesize.</param>
+    /// <param name="options">TTS options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Observable of audio chunks.</returns>
+    IObservable<SpeechChunk> StreamSynthesis(
+        IObservable<string> textStream,
+        TextToSpeechOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Synthesizes text incrementally, emitting audio as each sentence is ready.
+    /// Uses sentence-boundary detection for natural pauses between chunks.
+    /// </summary>
+    /// <param name="text">Complete text to synthesize.</param>
+    /// <param name="options">TTS options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Observable of audio chunks with sentence boundaries marked.</returns>
+    IObservable<SpeechChunk> StreamSynthesisIncremental(
+        string text,
+        TextToSpeechOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Synthesizes a single sentence/chunk immediately and returns the audio.
+    /// Lower latency than full synthesis, suitable for streaming pipelines.
+    /// </summary>
+    /// <param name="text">The text chunk to synthesize (should be sentence-sized).</param>
+    /// <param name="options">TTS options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The speech chunk result.</returns>
+    Task<Result<SpeechChunk, string>> SynthesizeChunkAsync(
+        string text,
+        TextToSpeechOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Stops any ongoing synthesis immediately (for barge-in support).
+    /// </summary>
+    void InterruptSynthesis();
+
+    /// <summary>
+    /// Gets whether synthesis is currently in progress.
+    /// </summary>
+    bool IsSynthesizing { get; }
+
+    /// <summary>
+    /// Gets whether streaming synthesis is supported by this provider.
+    /// </summary>
+    bool SupportsStreaming { get; }
+}
+
+/// <summary>
+/// Extension methods for streaming TTS services.
+/// </summary>
+public static class StreamingTtsExtensions
+{
+    /// <summary>
+    /// Sentence boundary detection pattern for natural TTS chunking.
+    /// </summary>
+    private static readonly char[] SentenceEnders = ['.', '!', '?', '\n'];
+    private const int MinChunkSize = 15;
+    private const int MaxChunkSize = 200;
+
+    /// <summary>
+    /// Buffers a token stream into sentence-sized chunks for natural TTS.
+    /// </summary>
+    /// <param name="tokens">The incoming token stream.</param>
+    /// <returns>Observable of sentence-sized text chunks.</returns>
+    public static IObservable<string> BufferIntoSentences(this IObservable<string> tokens)
+    {
+        return System.Reactive.Linq.Observable.Create<string>(observer =>
+        {
+            var buffer = new System.Text.StringBuilder();
+
+            return tokens.Subscribe(
+                onNext: token =>
+                {
+                    buffer.Append(token);
+
+                    var text = buffer.ToString();
+                    var lastEnder = text.LastIndexOfAny(SentenceEnders);
+
+                    // Emit if we have a sentence boundary and enough content
+                    if (lastEnder >= MinChunkSize)
+                    {
+                        var sentence = text[..(lastEnder + 1)].Trim();
+                        if (!string.IsNullOrWhiteSpace(sentence))
+                        {
+                            observer.OnNext(sentence);
+                        }
+
+                        // Keep remainder in buffer
+                        buffer.Clear();
+                        if (lastEnder + 1 < text.Length)
+                        {
+                            buffer.Append(text[(lastEnder + 1)..]);
+                        }
+                    }
+                    else if (buffer.Length > MaxChunkSize)
+                    {
+                        // Force emit if buffer is too large (no sentence boundary found)
+                        var chunk = text.Trim();
+                        if (!string.IsNullOrWhiteSpace(chunk))
+                        {
+                            observer.OnNext(chunk);
+                        }
+
+                        buffer.Clear();
+                    }
+                },
+                onError: observer.OnError,
+                onCompleted: () =>
+                {
+                    // Flush remaining buffer
+                    var remaining = buffer.ToString().Trim();
+                    if (!string.IsNullOrWhiteSpace(remaining))
+                    {
+                        observer.OnNext(remaining);
+                    }
+
+                    observer.OnCompleted();
+                });
+        });
+    }
+
+    /// <summary>
+    /// Splits text into sentences for incremental synthesis.
+    /// </summary>
+    /// <param name="text">The text to split.</param>
+    /// <returns>Enumerable of sentences.</returns>
+    public static IEnumerable<string> SplitIntoSentences(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            yield break;
+        }
+
+        var pattern = new System.Text.RegularExpressions.Regex(
+            @"(?<=[.!?])\s+|(?<=\n)",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        var sentences = pattern.Split(text);
+
+        foreach (var sentence in sentences)
+        {
+            var trimmed = sentence.Trim();
+            if (!string.IsNullOrWhiteSpace(trimmed))
+            {
+                yield return trimmed;
+            }
+        }
+    }
+}

--- a/src/Ouroboros.Abstractions/Providers/TextToSpeech/ITextToSpeechService.cs
+++ b/src/Ouroboros.Abstractions/Providers/TextToSpeech/ITextToSpeechService.cs
@@ -1,0 +1,129 @@
+// <copyright file="ITextToSpeechService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Providers.TextToSpeech;
+
+/// <summary>
+/// Represents the result of a text-to-speech synthesis.
+/// </summary>
+/// <param name="AudioData">The synthesized audio data.</param>
+/// <param name="Format">The audio format (e.g., "mp3", "wav", "opus").</param>
+/// <param name="Duration">Optional duration in seconds.</param>
+public sealed record SpeechResult(
+    byte[] AudioData,
+    string Format,
+    double? Duration = null);
+
+/// <summary>
+/// Available voices for text-to-speech synthesis.
+/// </summary>
+public enum TtsVoice
+{
+    /// <summary>Alloy - neutral, balanced voice.</summary>
+    Alloy,
+
+    /// <summary>Echo - warm, conversational voice.</summary>
+    Echo,
+
+    /// <summary>Fable - expressive, narrative voice.</summary>
+    Fable,
+
+    /// <summary>Onyx - deep, authoritative voice.</summary>
+    Onyx,
+
+    /// <summary>Nova - friendly, upbeat voice.</summary>
+    Nova,
+
+    /// <summary>Shimmer - soft, gentle voice.</summary>
+    Shimmer,
+}
+
+/// <summary>
+/// Configuration options for text-to-speech synthesis.
+/// </summary>
+/// <param name="Voice">The voice to use for synthesis.</param>
+/// <param name="Speed">Speech speed (0.25 to 4.0, default 1.0).</param>
+/// <param name="Format">Output format: "mp3", "opus", "aac", "flac", "wav", "pcm".</param>
+/// <param name="Model">TTS model to use (e.g., "tts-1", "tts-1-hd").</param>
+/// <param name="IsWhisper">If true, uses a soft whispering style for inner thoughts.</param>
+public sealed record TextToSpeechOptions(
+    TtsVoice Voice = TtsVoice.Alloy,
+    double Speed = 1.0,
+    string Format = "mp3",
+    string? Model = null,
+    bool IsWhisper = false);
+
+/// <summary>
+/// Defines the contract for text-to-speech synthesis services.
+/// Supports various providers (OpenAI TTS, Azure, local engines, etc.).
+/// </summary>
+public interface ITextToSpeechService
+{
+    /// <summary>
+    /// Gets the name of the text-to-speech provider.
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Gets the available voices.
+    /// </summary>
+    IReadOnlyList<string> AvailableVoices { get; }
+
+    /// <summary>
+    /// Gets the supported output formats.
+    /// </summary>
+    IReadOnlyList<string> SupportedFormats { get; }
+
+    /// <summary>
+    /// Gets the maximum input text length.
+    /// </summary>
+    int MaxInputLength { get; }
+
+    /// <summary>
+    /// Synthesizes speech from text and returns the audio data.
+    /// </summary>
+    /// <param name="text">The text to synthesize.</param>
+    /// <param name="options">Optional synthesis options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The synthesized audio result.</returns>
+    Task<Result<SpeechResult, string>> SynthesizeAsync(
+        string text,
+        TextToSpeechOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Synthesizes speech from text and saves to a file.
+    /// </summary>
+    /// <param name="text">The text to synthesize.</param>
+    /// <param name="outputPath">Path to save the audio file.</param>
+    /// <param name="options">Optional synthesis options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The path to the saved audio file.</returns>
+    Task<Result<string, string>> SynthesizeToFileAsync(
+        string text,
+        string outputPath,
+        TextToSpeechOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Synthesizes speech from text and writes to a stream.
+    /// </summary>
+    /// <param name="text">The text to synthesize.</param>
+    /// <param name="outputStream">Stream to write the audio data.</param>
+    /// <param name="options">Optional synthesis options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The audio format of the written data.</returns>
+    Task<Result<string, string>> SynthesizeToStreamAsync(
+        string text,
+        Stream outputStream,
+        TextToSpeechOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks if the service is available and properly configured.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if the service is available.</returns>
+    Task<bool> IsAvailableAsync(CancellationToken ct = default);
+}


### PR DESCRIPTION
## Summary

- Move 40 interface files (with associated DTOs/records/enums) from engine projects into `Ouroboros.Abstractions`
- Add `Ouroboros.Core`, `Ouroboros.Domain`, `Ouroboros.Tools` project references and `System.Reactive` package
- Add `GlobalUsings.cs` for System and foundation-layer namespaces
- Namespaces preserved (e.g. `Ouroboros.Agent.MetaAI`) so engine consumers resolve types transparently

Companion PR: https://github.com/PMeeske/ouroboros-engine/pull/16

## Test plan

- [ ] Verify Abstractions project builds with new interfaces and references
- [ ] Confirm no namespace conflicts with existing foundation types

https://claude.ai/code/session_01LacVXZiDRd3oxcWZxzhJzH