### PR TITLE
refactor(steps): align contextual step layer with repo quality standards

### DIFF
--- a/src/Ouroboros.Core/Core/Steps/ContextualDef.cs
+++ b/src/Ouroboros.Core/Core/Steps/ContextualDef.cs
@@ -1,36 +1,61 @@
-﻿namespace Ouroboros.Core.Steps;
+// <copyright file="ContextualDef.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// </copyright>
+
+namespace Ouroboros.Core.Steps;
 
 /// <summary>
-/// Helper class for creating contextual step definitions
+/// Static helper class providing factory methods for creating <see cref="ContextualStepDefinition{TIn, TOut, TContext}"/> instances.
 /// </summary>
 public static class ContextualDef
 {
     /// <summary>
-    /// Create from pure function
+    /// Creates a contextual step definition by lifting a pure synchronous function.
     /// </summary>
+    /// <typeparam name="TIn">The input type.</typeparam>
+    /// <typeparam name="TOut">The output type.</typeparam>
+    /// <typeparam name="TContext">The context type.</typeparam>
+    /// <param name="func">The synchronous function to lift.</param>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
+    /// <returns>A contextual step definition wrapping <paramref name="func"/>.</returns>
     public static ContextualStepDefinition<TIn, TOut, TContext> LiftPure<TIn, TOut, TContext>(
         Func<TIn, TOut> func,
         string? log = null)
         => ContextualStepDefinition<TIn, TOut, TContext>.LiftPure(func, log);
 
     /// <summary>
-    /// Create from pure Step
+    /// Creates a contextual step definition from an existing pure async step.
     /// </summary>
+    /// <typeparam name="TIn">The input type.</typeparam>
+    /// <typeparam name="TOut">The output type.</typeparam>
+    /// <typeparam name="TContext">The context type.</typeparam>
+    /// <param name="step">The pure async step to wrap.</param>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
+    /// <returns>A contextual step definition wrapping <paramref name="step"/>.</returns>
     public static ContextualStepDefinition<TIn, TOut, TContext> FromPure<TIn, TOut, TContext>(
         Step<TIn, TOut> step,
         string? log = null)
         => ContextualStepDefinition<TIn, TOut, TContext>.FromPure(step, log);
 
     /// <summary>
-    /// Create from context-dependent step factory
+    /// Creates a contextual step definition from a context-dependent step factory.
     /// </summary>
+    /// <typeparam name="TIn">The input type.</typeparam>
+    /// <typeparam name="TOut">The output type.</typeparam>
+    /// <typeparam name="TContext">The context type.</typeparam>
+    /// <param name="ctxStep">A step that accepts a context and returns an inner step.</param>
+    /// <returns>A contextual step definition that resolves its inner step from the context at execution time.</returns>
     public static ContextualStepDefinition<TIn, TOut, TContext> FromContext<TIn, TOut, TContext>(
         Step<TContext, Step<TIn, TOut>> ctxStep)
         => ContextualStepDefinition<TIn, TOut, TContext>.FromContext(ctxStep);
 
     /// <summary>
-    /// Identity contextual step
+    /// Creates a contextual step definition that acts as the identity: returns the input unchanged.
     /// </summary>
+    /// <typeparam name="TIn">The input and output type.</typeparam>
+    /// <typeparam name="TContext">The context type (unused).</typeparam>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
+    /// <returns>A contextual step definition that passes the input through unmodified.</returns>
     public static ContextualStepDefinition<TIn, TIn, TContext> Identity<TIn, TContext>(string? log = null)
         => LiftPure<TIn, TIn, TContext>(x => x, log);
 }

--- a/src/Ouroboros.Core/Core/Steps/ContextualStep.cs
+++ b/src/Ouroboros.Core/Core/Steps/ContextualStep.cs
@@ -1,66 +1,91 @@
-// <copyright file="ContextualStep.cs" company="PlaceholderCompany">
-// Copyright (c) PlaceholderCompany. All rights reserved.
+// <copyright file="ContextualStep.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
 // </copyright>
 
 namespace Ouroboros.Core.Steps;
 
 /// <summary>
-/// A contextual step that depends on context and produces logs (Reader + Writer pattern).
+/// A contextual step that depends on a context and produces logs (Reader + Writer pattern).
 /// </summary>
-/// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+/// <typeparam name="TIn">The input type.</typeparam>
+/// <typeparam name="TOut">The output type.</typeparam>
+/// <typeparam name="TContext">The context type.</typeparam>
+/// <param name="input">The input value.</param>
+/// <param name="context">The context value.</param>
+/// <returns>A task that resolves to the output value paired with accumulated log entries.</returns>
 public delegate Task<(TOut result, List<string> logs)> ContextualStep<in TIn, TOut, in TContext>(TIn input, TContext context);
 
 /// <summary>
-/// Static factory methods for contextual steps.
+/// Static factory methods for creating contextual steps.
 /// </summary>
 public static class ContextualStep
 {
     /// <summary>
-    /// Lift a pure function into a contextual step.
+    /// Lifts a pure synchronous function into a contextual step.
     /// </summary>
-    /// <returns></returns>
+    /// <typeparam name="TIn">The input type.</typeparam>
+    /// <typeparam name="TOut">The output type.</typeparam>
+    /// <typeparam name="TContext">The context type (unused but required by the delegate signature).</typeparam>
+    /// <param name="func">The pure function to lift.</param>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
+    /// <returns>A contextual step that applies <paramref name="func"/> and emits <paramref name="log"/>.</returns>
     public static ContextualStep<TIn, TOut, TContext> LiftPure<TIn, TOut, TContext>(
         Func<TIn, TOut> func,
         string? log = null)
-        => async (input, context) =>
-        {
-            await Task.Yield();
-            TOut? result = func(input);
-            List<string> logs = log != null ? [log] : new List<string>();
-            return (result, logs);
-        };
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        return (input, _) => Task.FromResult((func(input), log != null ? new List<string> { log } : new List<string>()));
+    }
 
     /// <summary>
-    /// Create from pure Step.
+    /// Creates a contextual step from an existing pure async step.
     /// </summary>
-    /// <returns></returns>
+    /// <typeparam name="TIn">The input type.</typeparam>
+    /// <typeparam name="TOut">The output type.</typeparam>
+    /// <typeparam name="TContext">The context type (unused but required by the delegate signature).</typeparam>
+    /// <param name="step">The pure async step to wrap.</param>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
+    /// <returns>A contextual step that delegates to <paramref name="step"/> and emits <paramref name="log"/>.</returns>
     public static ContextualStep<TIn, TOut, TContext> FromPure<TIn, TOut, TContext>(
         Step<TIn, TOut> step,
         string? log = null)
-        => async (input, context) =>
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        return async (input, _) =>
         {
-            TOut? result = await step(input);
-            List<string> logs = log != null ? [log] : new List<string>();
-            return (result, logs);
+            TOut result = await step(input).ConfigureAwait(false);
+            return (result, log != null ? new List<string> { log } : new List<string>());
         };
+    }
 
     /// <summary>
-    /// Create from context-dependent step factory.
+    /// Creates a contextual step from a context-dependent step factory.
+    /// The context is used to produce an inner step, which is then applied to the input.
     /// </summary>
-    /// <returns></returns>
+    /// <typeparam name="TIn">The input type.</typeparam>
+    /// <typeparam name="TOut">The output type.</typeparam>
+    /// <typeparam name="TContext">The context type.</typeparam>
+    /// <param name="contextStep">A step that resolves a context into an inner step.</param>
+    /// <returns>A contextual step that resolves the context at execution time.</returns>
     public static ContextualStep<TIn, TOut, TContext> FromContext<TIn, TOut, TContext>(
         Step<TContext, Step<TIn, TOut>> contextStep)
-        => async (input, context) =>
+    {
+        ArgumentNullException.ThrowIfNull(contextStep);
+        return async (input, context) =>
         {
-            Step<TIn, TOut> innerStep = await contextStep(context);
-            TOut? result = await innerStep(input);
-            return (result, []);
+            Step<TIn, TOut> innerStep = await contextStep(context).ConfigureAwait(false);
+            TOut result = await innerStep(input).ConfigureAwait(false);
+            return (result, new List<string>());
         };
+    }
 
     /// <summary>
-    /// Identity contextual step.
+    /// Creates a contextual identity step that returns the input unchanged.
     /// </summary>
-    /// <returns></returns>
+    /// <typeparam name="TIn">The input and output type.</typeparam>
+    /// <typeparam name="TContext">The context type (unused).</typeparam>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
+    /// <returns>A contextual step that passes the input through unmodified.</returns>
     public static ContextualStep<TIn, TIn, TContext> Identity<TIn, TContext>(string? log = null)
         => LiftPure<TIn, TIn, TContext>(x => x, log);
 }

--- a/src/Ouroboros.Core/Core/Steps/ContextualStepDefinition.cs
+++ b/src/Ouroboros.Core/Core/Steps/ContextualStepDefinition.cs
@@ -1,8 +1,6 @@
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-// ==========================================================
-// Contextual Step Definition - Append-only Builder Pattern
-// Implements the Reader/Writer monad pattern with fluent composition
-// ==========================================================
+// <copyright file="ContextualStepDefinition.cs" company="Ouroboros">
+// Copyright (c) Ouroboros. All rights reserved.
+// </copyright>
 
 namespace Ouroboros.Core.Steps;
 
@@ -10,68 +8,96 @@ namespace Ouroboros.Core.Steps;
 /// Append-only builder for contextual pipelines:
 /// steps that depend on a context (Reader) and may log/trace (Writer).
 /// </summary>
-public struct ContextualStepDefinition<TIn, TOut, TContext>
+/// <typeparam name="TIn">The input type.</typeparam>
+/// <typeparam name="TOut">The output type.</typeparam>
+/// <typeparam name="TContext">The context type.</typeparam>
+public readonly struct ContextualStepDefinition<TIn, TOut, TContext>
 {
-    private ContextualStep<TIn, TOut, TContext> _compiled;
+    private readonly ContextualStep<TIn, TOut, TContext> _compiled;
 
     /// <summary>
-    /// Constructor: from "context → pure step"
+    /// Initializes a new instance of <see cref="ContextualStepDefinition{TIn, TOut, TContext}"/>
+    /// from a context-to-step factory.
     /// </summary>
+    /// <param name="pure">A step that accepts a context and returns an inner step.</param>
     public ContextualStepDefinition(Step<TContext, Step<TIn, TOut>> pure)
     {
-        this._compiled = async (input, context) =>
-        {
-            Step<TIn, TOut> innerStep = await pure(context);  // Step<TIn,TOut>
-            TOut? result = await innerStep(input);  // apply inner step
-            return (result, []);
-        };
+        ArgumentNullException.ThrowIfNull(pure);
+        _compiled = ContextualStep.FromContext<TIn, TOut, TContext>(pure);
     }
 
     /// <summary>
-    /// Constructor: from compiled contextual step
+    /// Initializes a new instance of <see cref="ContextualStepDefinition{TIn, TOut, TContext}"/>
+    /// from a compiled contextual step.
     /// </summary>
+    /// <param name="step">The compiled contextual step delegate.</param>
     public ContextualStepDefinition(ContextualStep<TIn, TOut, TContext> step)
     {
-        this._compiled = step;
+        ArgumentNullException.ThrowIfNull(step);
+        _compiled = step;
     }
 
     /// <summary>
-    /// Constructor: from pure function
+    /// Initializes a new instance of <see cref="ContextualStepDefinition{TIn, TOut, TContext}"/>
+    /// from a pure synchronous function.
     /// </summary>
+    /// <param name="func">The synchronous function to lift.</param>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
     public ContextualStepDefinition(Func<TIn, TOut> func, string? log = null)
     {
-        this._compiled = ContextualStep.LiftPure<TIn, TOut, TContext>(func, log);
+        _compiled = ContextualStep.LiftPure<TIn, TOut, TContext>(func, log);
     }
 
     /// <summary>
-    /// Constructor: from pure Step{TIn,TOut}
+    /// Initializes a new instance of <see cref="ContextualStepDefinition{TIn, TOut, TContext}"/>
+    /// from a pure async step.
     /// </summary>
-    /// <param name="pure">The pure step to lift.</param>
-    /// <param name="log">Optional logging string.</param>
+    /// <param name="pure">The pure async step to wrap.</param>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
     public ContextualStepDefinition(Step<TIn, TOut> pure, string? log = null)
     {
-        this._compiled = ContextualStep.FromPure<TIn, TOut, TContext>(pure, log);
+        _compiled = ContextualStep.FromPure<TIn, TOut, TContext>(pure, log);
     }
 
     /// <summary>
-    /// Static Lift helpers
+    /// Creates a definition by lifting a pure synchronous function.
     /// </summary>
+    /// <param name="func">The synchronous function to lift.</param>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
+    /// <returns>A new definition wrapping <paramref name="func"/>.</returns>
     public static ContextualStepDefinition<TIn, TOut, TContext> LiftPure(Func<TIn, TOut> func, string? log = null)
         => new(func, log);
 
-    public static ContextualStepDefinition<TIn, TOut, TContext> FromPure(Step<TIn, TOut> step, string? log = null) => new(step, log);
-
-    public static ContextualStepDefinition<TIn, TOut, TContext> FromContext(Step<TContext, Step<TIn, TOut>> ctxStep) => new(ctxStep);
+    /// <summary>
+    /// Creates a definition from a pure async step.
+    /// </summary>
+    /// <param name="step">The pure async step to wrap.</param>
+    /// <param name="log">An optional log entry to emit on each invocation.</param>
+    /// <returns>A new definition wrapping <paramref name="step"/>.</returns>
+    public static ContextualStepDefinition<TIn, TOut, TContext> FromPure(Step<TIn, TOut> step, string? log = null)
+        => new(step, log);
 
     /// <summary>
-    /// Implicit conversion to compiled step
+    /// Creates a definition from a context-dependent step factory.
     /// </summary>
+    /// <param name="ctxStep">A step that accepts a context and returns an inner step.</param>
+    /// <returns>A new definition that resolves its inner step from the context at execution time.</returns>
+    public static ContextualStepDefinition<TIn, TOut, TContext> FromContext(Step<TContext, Step<TIn, TOut>> ctxStep)
+        => new(ctxStep);
+
+    /// <summary>
+    /// Implicitly converts the definition to its compiled contextual step delegate.
+    /// </summary>
+    /// <param name="d">The definition to convert.</param>
     public static implicit operator ContextualStep<TIn, TOut, TContext>(ContextualStepDefinition<TIn, TOut, TContext> d)
         => d._compiled;
 
     /// <summary>
-    /// Pipe method: append contextual step
+    /// Appends a contextual step, producing a new definition whose output flows through <paramref name="next"/>.
     /// </summary>
+    /// <typeparam name="TNext">The output type of the appended step.</typeparam>
+    /// <param name="next">The contextual step to append.</param>
+    /// <returns>A new definition representing the composed pipeline.</returns>
     public ContextualStepDefinition<TIn, TNext, TContext> Pipe<TNext>(ContextualStep<TOut, TNext, TContext> next)
     {
         ContextualStep<TIn, TNext, TContext> newCompiled = _compiled.Then(next);
@@ -79,8 +105,12 @@ public struct ContextualStepDefinition<TIn, TOut, TContext>
     }
 
     /// <summary>
-    /// Pipe method: append pure step
+    /// Appends a pure async step, producing a new definition whose output flows through <paramref name="pure"/>.
     /// </summary>
+    /// <typeparam name="TNext">The output type of the appended step.</typeparam>
+    /// <param name="pure">The pure async step to append.</param>
+    /// <param name="log">An optional log entry to emit when <paramref name="pure"/> is invoked.</param>
+    /// <returns>A new definition representing the composed pipeline.</returns>
     public ContextualStepDefinition<TIn, TNext, TContext> Pipe<TNext>(Step<TOut, TNext> pure, string? log = null)
     {
         ContextualStep<TOut, TNext, TContext> contextualNext = ContextualStep.FromPure<TOut, TNext, TContext>(pure, log);
@@ -88,8 +118,12 @@ public struct ContextualStepDefinition<TIn, TOut, TContext>
     }
 
     /// <summary>
-    /// Pipe method: append pure function
+    /// Appends a pure synchronous function, producing a new definition whose output flows through <paramref name="func"/>.
     /// </summary>
+    /// <typeparam name="TNext">The output type of the appended function.</typeparam>
+    /// <param name="func">The synchronous function to append.</param>
+    /// <param name="log">An optional log entry to emit when <paramref name="func"/> is invoked.</param>
+    /// <returns>A new definition representing the composed pipeline.</returns>
     public ContextualStepDefinition<TIn, TNext, TContext> Pipe<TNext>(Func<TOut, TNext> func, string? log = null)
     {
         ContextualStep<TOut, TNext, TContext> contextualNext = ContextualStep.LiftPure<TOut, TNext, TContext>(func, log);
@@ -97,32 +131,48 @@ public struct ContextualStepDefinition<TIn, TOut, TContext>
     }
 
     /// <summary>
-    /// Execute pipeline (synchronous convenience method)
+    /// Executes the pipeline asynchronously with the given input and context.
     /// </summary>
-    public async Task<(TOut result, List<string> logs)> InvokeAsync(TIn input, TContext context)
-        => await _compiled(input, context);
+    /// <param name="input">The input value.</param>
+    /// <param name="context">The context value.</param>
+    /// <returns>A task that resolves to the output value paired with accumulated log entries.</returns>
+    public Task<(TOut result, List<string> logs)> InvokeAsync(TIn input, TContext context)
+        => _compiled(input, context);
 
     /// <summary>
-    /// Execute pipeline (synchronous convenience method)
+    /// Executes the pipeline synchronously by blocking the calling thread.
     /// </summary>
+    /// <remarks>
+    /// WARNING: This can cause deadlocks if called from a synchronization context.
+    /// Prefer <see cref="InvokeAsync"/> throughout the call stack wherever possible.
+    /// </remarks>
+    /// <param name="input">The input value.</param>
+    /// <param name="context">The context value.</param>
+    /// <returns>The output value paired with accumulated log entries.</returns>
     public (TOut result, List<string> logs) Invoke(TIn input, TContext context)
-        => InvokeAsync(input, context).GetAwaiter().GetResult();
+        => Task.Run(() => _compiled(input, context)).GetAwaiter().GetResult();
 
     /// <summary>
-    /// Forget context: collapse into pure Step
+    /// Collapses the definition to a pure step by binding the context, retaining the log output.
     /// </summary>
+    /// <param name="context">The context to bind.</param>
+    /// <returns>A pure step that returns the result and logs.</returns>
     public Step<TIn, (TOut result, List<string> logs)> Forget(TContext context)
         => _compiled.Forget(context);
 
     /// <summary>
-    /// Forget context and logs: collapse to pure result Step
+    /// Collapses the definition to a pure step by discarding both the context and the logs.
     /// </summary>
+    /// <param name="context">The context to bind.</param>
+    /// <returns>A pure step that returns only the result.</returns>
     public Step<TIn, TOut> ForgetAll(TContext context)
         => _compiled.ForgetAll(context);
 
     /// <summary>
-    /// Add logging to the current step
+    /// Appends a static log message that is emitted after the current step completes.
     /// </summary>
+    /// <param name="logMessage">The message to append to the log.</param>
+    /// <returns>A new definition that appends <paramref name="logMessage"/> to every execution.</returns>
     public ContextualStepDefinition<TIn, TOut, TContext> WithLog(string logMessage)
     {
         ContextualStep<TIn, TOut, TContext> newCompiled = _compiled.WithLog(logMessage);
@@ -130,8 +180,10 @@ public struct ContextualStepDefinition<TIn, TOut, TContext>
     }
 
     /// <summary>
-    /// Add conditional logging based on result
+    /// Appends a conditional log message derived from the step's output.
     /// </summary>
+    /// <param name="logFunction">A function that maps the output to a log message, or <see langword="null"/> to suppress logging.</param>
+    /// <returns>A new definition that conditionally appends a log entry after each execution.</returns>
     public ContextualStepDefinition<TIn, TOut, TContext> WithConditionalLog(Func<TOut, string?> logFunction)
     {
         ContextualStep<TIn, TOut, TContext> newCompiled = _compiled.WithConditionalLog(logFunction);
@@ -139,8 +191,9 @@ public struct ContextualStepDefinition<TIn, TOut, TContext>
     }
 
     /// <summary>
-    /// Convert to Result-based contextual step for error handling
+    /// Wraps the definition so that exceptions are caught and returned as a <see cref="Result{TOut, Exception}"/> failure.
     /// </summary>
+    /// <returns>A new definition that never throws; all errors are captured in the result.</returns>
     public ContextualStepDefinition<TIn, Result<TOut, Exception>, TContext> TryStep()
     {
         ContextualStep<TIn, Result<TOut, Exception>, TContext> newCompiled = _compiled.TryStep();
@@ -148,8 +201,11 @@ public struct ContextualStepDefinition<TIn, TOut, TContext>
     }
 
     /// <summary>
-    /// Convert to Option-based contextual step
+    /// Wraps the definition so that the output is filtered through <paramref name="predicate"/>,
+    /// returning <see cref="Option{TOut}.None"/> when the predicate fails or an exception is thrown.
     /// </summary>
+    /// <param name="predicate">A function that determines whether the output should be present.</param>
+    /// <returns>A new definition that returns an <see cref="Option{TOut}"/>.</returns>
     public ContextualStepDefinition<TIn, Option<TOut>, TContext> TryOption(Func<TOut, bool> predicate)
     {
         ContextualStep<TIn, Option<TOut>, TContext> newCompiled = _compiled.TryOption(predicate);

--- a/src/Ouroboros.Core/Core/Steps/ContextualStepDefinition.cs
+++ b/src/Ouroboros.Core/Core/Steps/ContextualStepDefinition.cs
@@ -150,7 +150,11 @@ public readonly struct ContextualStepDefinition<TIn, TOut, TContext>
     /// <param name="context">The context value.</param>
     /// <returns>The output value paired with accumulated log entries.</returns>
     public (TOut result, List<string> logs) Invoke(TIn input, TContext context)
-        => Task.Run(() => _compiled(input, context)).GetAwaiter().GetResult();
+    {
+        // Copy to a local so the lambda does not capture 'this' (not allowed in structs).
+        var compiled = _compiled;
+        return Task.Run(() => compiled(input, context)).GetAwaiter().GetResult();
+    }
 
     /// <summary>
     /// Collapses the definition to a pure step by binding the context, retaining the log output.


### PR DESCRIPTION
- Remove #pragma warning disable CS1591 from ContextualStepDefinition
- Add complete XML documentation (summary, typeparam, param, returns) to all
  public members across ContextualStep, ContextualStepDefinition,
  ContextualStepExtensions, ContextualDef, and StepDefinition
- Fix placeholder copyright headers (PlaceholderCompany → Ouroboros)
- Eliminate unnecessary async state-machine overhead: remove Task.Yield()
  from LiftPure and drop async/await around Task.FromResult in StepDefinition
- Add .ConfigureAwait(false) to all awaited calls in contextual extensions
- Replace mutable struct with readonly struct in ContextualStepDefinition
- Add ArgumentNullException.ThrowIfNull guards to all factory methods
- Rename bare field compiled → _compiled to match underscore-prefix convention
- Fix Invoke() to use Task.Run to avoid deadlocking a synchronization context
- Expand Then() log combination to pre-size the combined list

https://claude.ai/code/session_01KDGuGD1NcecE1dQwNWNVpf