### PR TITLE
chore: harden .gitignore with security exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,18 @@ StrykerOutput/
 # Logs
 logs/
 *.log
+
+# Security - prevent accidental credential commits
+.env
+.env.*
+*.env
+appsettings.*.local.json
+appsettings.Local.json
+credentials.json
+secrets.json
+launchSettings.json
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks


### PR DESCRIPTION
## Summary
- Adds security-related entries to `.gitignore` to prevent accidental commits of credentials, certificates, and environment files
- New entries: `.env`, `.env.*`, `*.env`, `appsettings.*.local.json`, `appsettings.Local.json`, `credentials.json`, `secrets.json`, `launchSettings.json`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`

## Test plan
- [ ] Verify `.gitignore` entries are syntactically correct
- [ ] Confirm no tracked files are affected by the new patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)